### PR TITLE
Support Kubernetes Admission Controller OPA rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## v1.1.0
+
+### New Features
+
+- **Kubernetes Admission Controller compatibility**: New `inputFormat: kubernetes-admission`
+  setting in `PulumiPolicy.yaml` enables drop-in reuse of existing OPA Gatekeeper constraint
+  template rules. Pulumi automatically wraps Kubernetes resources in the Gatekeeper
+  AdmissionReview structure (`input.review.object`, `input.review.kind`, etc.) so `.rego`
+  files work without modification. Non-Kubernetes resources are automatically skipped. (#35)
+
+- **Gatekeeper `input.parameters` support**: Per-policy configuration properties are injected
+  as `input.parameters` when using the `kubernetes-admission` input format, matching the
+  Gatekeeper Constraint parameter convention. (#35)
+
+- **Gatekeeper violation map format**: Rules returning `violation[{"msg": msg}]` (map values)
+  are now handled alongside the existing string-based `deny[msg]` format. (#35)
+
+### Improvements
+
+- `PulumiPolicy.yaml` manifest is now parsed at load time, populating the policy pack
+  description and validating the `inputFormat` field.
+- Added new example: `examples/policy-kubernetes-gatekeeper/` demonstrating Gatekeeper-style
+  policy reuse.
+
 ## v1.0.0
 
 ### Summary

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ pulumi preview --policy-pack ./policies
 - [Quick Start](#quick-start)
 - [Policy Examples](#policy-examples)
 - [Resource Input Structure](#resource-input-structure)
+- [Kubernetes Admission Controller Compatibility](#kubernetes-admission-controller-compatibility)
 - [Stack-Level Policies](#stack-level-policies)
 - [Policy Configuration](#policy-configuration)
 - [Policy Metadata (OPA Annotations)](#policy-metadata-opa-annotations)
@@ -84,6 +85,8 @@ Create `PulumiPolicy.yaml`:
 ```yaml
 description: My Security Policies
 runtime: opa
+# Optional: set inputFormat to "kubernetes-admission" for Gatekeeper-compatible rules.
+# See "Kubernetes Admission Controller Compatibility" below.
 ```
 
 Create `s3-security.rego`:
@@ -378,6 +381,116 @@ deny_dangerous_type[msg] {
 
 ---
 
+## Kubernetes Admission Controller Compatibility
+
+If you have existing [OPA Gatekeeper](https://open-policy-agent.github.io/gatekeeper/) constraint templates, you can reuse them directly with Pulumi by setting `inputFormat: kubernetes-admission` in `PulumiPolicy.yaml`.
+
+### How It Works
+
+Standard Pulumi OPA policies see resource properties overlaid at the top level of `input`. Gatekeeper rules expect a different structure: `input.review.object.<properties>`. When `inputFormat: kubernetes-admission` is active, the analyzer automatically wraps Kubernetes resources in the Gatekeeper AdmissionReview structure before passing them to OPA:
+
+```
+input.review.object     — the full Kubernetes resource (properties + synthesized apiVersion/kind)
+input.review.kind       — { group, version, kind }
+input.review.name       — resource name (from metadata.name or Pulumi logical name)
+input.review.namespace  — namespace (from metadata.namespace, empty if not set)
+input.review.operation  — always "CREATE"
+input.parameters        — per-rule policy configuration properties
+input._pulumi           — escape hatch for Pulumi metadata (type, urn, name, options, provider)
+```
+
+Non-Kubernetes resources (e.g. `aws:s3/bucket:Bucket`) are silently skipped when this mode is active, since Gatekeeper rules are meaningless for non-K8s resources.
+
+### Setup
+
+Set `inputFormat` in your `PulumiPolicy.yaml`:
+
+```yaml
+description: Kubernetes Gatekeeper Policy Pack
+runtime: opa
+inputFormat: kubernetes-admission
+```
+
+Then drop in your existing Gatekeeper `.rego` files as-is:
+
+```rego
+package gatekeeper
+
+import rego.v1
+
+# This rule works identically in Gatekeeper and Pulumi
+violation contains {"msg": msg} if {
+    not input.review.object.metadata.labels["app"]
+    msg := sprintf("%s '%s' is missing required label: app",
+        [input.review.kind.kind, input.review.name])
+}
+```
+
+### Using `input.parameters`
+
+Gatekeeper Constraint parameters map to `input.parameters`. Configure them via the standard Pulumi policy configuration — each rule's `properties` are injected as `input.parameters` before evaluation:
+
+**Policy** (`replica-limits.rego`):
+```rego
+package gatekeeper
+
+import rego.v1
+
+violation contains {"msg": msg} if {
+    input.review.object.spec.replicas > input.parameters.maxReplicas
+    msg := sprintf("Deployment '%s' has %d replicas, max allowed is %d",
+        [input.review.name, input.review.object.spec.replicas, input.parameters.maxReplicas])
+}
+```
+
+**Configuration** (passed via Pulumi):
+```json
+{
+    "violation": {
+        "properties": {
+            "maxReplicas": 5
+        }
+    }
+}
+```
+
+This coexists with the standard `data.config.<rule_name>` mechanism — both work simultaneously.
+
+### Accessing Pulumi Metadata
+
+When you need Pulumi-specific information (URN, resource options, provider) from within a Gatekeeper-style rule, use the `input._pulumi` escape hatch:
+
+```rego
+violation contains {"msg": msg} if {
+    contains(lower(input._pulumi.name), "prod")
+    not input._pulumi.options.protect
+    msg := sprintf("Production resource '%s' must have protect enabled", [input._pulumi.name])
+}
+```
+
+### Mixing with Standard Rules
+
+A policy pack uses one input format. If you need both standard Pulumi OPA rules and Gatekeeper-style rules, create separate policy packs — one with `inputFormat: kubernetes-admission` for your Gatekeeper rules, and one without for your standard rules.
+
+### Stack-Level Gatekeeper Rules
+
+Stack-level rules (`stack_deny`, `stack_violation`, `stack_warn`) work with the admission format too. Each resource in `input.resources` is wrapped in the AdmissionReview structure, and non-K8s resources are filtered out:
+
+```rego
+package gatekeeper
+
+import rego.v1
+
+stack_violation contains {"msg": msg} if {
+    r := input.resources[_]
+    not r.review.object.metadata.labels["app"]
+    msg := sprintf("%s '%s' is missing required label: app",
+        [r.review.kind.kind, r.review.name])
+}
+```
+
+---
+
 ## Stack-Level Policies
 
 Stack-level policies evaluate the entire set of resources in a stack, enabling cross-resource checks like counting resources, verifying relationships, or enforcing fleet-wide standards.
@@ -660,6 +773,14 @@ my-policies/
     └── fixtures/            # Test data
 ```
 
+### `PulumiPolicy.yaml` Fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `description` | No | Human-readable description of the policy pack |
+| `runtime` | Yes | Must be `opa` |
+| `inputFormat` | No | Set to `kubernetes-admission` for [Gatekeeper-compatible rules](#kubernetes-admission-controller-compatibility) |
+
 ### Package Naming
 
 All `.rego` files in a policy pack **must** use the same package name. Subpackages (e.g. `package aws.s3`) are not supported.
@@ -775,6 +896,13 @@ Always create fixtures for both valid (should pass) and invalid (should fail) co
 2. Verify the input structure matches your resource type
 3. Use `pulumi preview --policy-pack ./policies --debug` for verbose output
 
+### Gatekeeper rules not firing
+
+1. Verify `PulumiPolicy.yaml` includes `inputFormat: kubernetes-admission`
+2. Ensure the resource type starts with `kubernetes:` — non-K8s resources are skipped in admission mode
+3. Check that rules use `input.review.object.*` (not `input.*` directly)
+4. If using `input.parameters`, verify the rule name matches the config key and `properties` is non-empty
+
 ### Policy passes but shouldn't
 
 Add a temporary debug rule to inspect the input:
@@ -793,8 +921,9 @@ Ready-to-use policy packs in `examples/`:
 
 - **`examples/policy-aws/`** - AWS security policies with configuration, stack-level rules, and OPA annotations
 - **`examples/policy-kubernetes/`** - Kubernetes label and image policies with resource metadata access
+- **`examples/policy-kubernetes-gatekeeper/`** - Reuse OPA Gatekeeper constraint templates with `inputFormat: kubernetes-admission`
 
-Test policies in `tests/` covering AWS, Azure, Kubernetes, stack-level, and metadata scenarios. See the [Test Corpus Documentation](tests/README.md) for a complete catalog.
+Test policies in `tests/` covering AWS, Azure, Kubernetes, Kubernetes Admission Controller, stack-level, and metadata scenarios. See the [Test Corpus Documentation](tests/README.md) for a complete catalog.
 
 ### External Resources
 

--- a/cmd/pulumi-analyzer-policy-opa/admission_integration_test.go
+++ b/cmd/pulumi-analyzer-policy-opa/admission_integration_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025, Pulumi Corporation.
+// Copyright 2026, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/pulumi-analyzer-policy-opa/admission_integration_test.go
+++ b/cmd/pulumi-analyzer-policy-opa/admission_integration_test.go
@@ -1,0 +1,158 @@
+// Copyright 2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+)
+
+// TestKubernetesAdmission_Integration loads the kubernetes-admission test pack
+// and evaluates K8s resources through the full Analyze() path.
+func TestKubernetesAdmission_Integration(t *testing.T) {
+	t.Parallel()
+
+	packDir := filepath.Join("..", "..", "tests", "kubernetes-admission", "policies")
+	if _, err := os.Stat(packDir); os.IsNotExist(err) {
+		t.Skipf("test pack not found at %s", packDir)
+	}
+
+	// loadPolicyPack needs the dir containing both PulumiPolicy.yaml and rego files.
+	// The manifest is in the parent; copy setup into a temp dir that has both.
+	dir := t.TempDir()
+
+	// Copy PulumiPolicy.yaml.
+	manifestSrc := filepath.Join("..", "..", "tests", "kubernetes-admission", "PulumiPolicy.yaml")
+	manifest, err := os.ReadFile(manifestSrc)
+	if err != nil {
+		t.Fatalf("reading manifest: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "PulumiPolicy.yaml"), manifest, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Copy rego files.
+	entries, err := os.ReadDir(packDir)
+	if err != nil {
+		t.Fatalf("reading policy dir: %v", err)
+	}
+	for _, entry := range entries {
+		if filepath.Ext(entry.Name()) == ".rego" {
+			data, err := os.ReadFile(filepath.Join(packDir, entry.Name()))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(dir, entry.Name()), data, 0o644); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+
+	pack, e, err := loadPolicyPack(dir)
+	if err != nil {
+		t.Fatalf("loadPolicyPack failed: %v", err)
+	}
+	if pack.InputFormat != InputFormatKubernetesAdmission {
+		t.Fatalf("expected kubernetes-admission input format, got %q", pack.InputFormat)
+	}
+
+	a := NewAnalyzer(pack, e)
+
+	t.Run("K8sResourceWithLabelViolation", func(t *testing.T) {
+		t.Parallel()
+		resp, err := a.Analyze(plugin.AnalyzerResource{
+			URN:  resource.URN("urn:pulumi:stack::proj::kubernetes:apps/v1:Deployment::bad-deploy"),
+			Type: tokens.Type("kubernetes:apps/v1:Deployment"),
+			Name: "bad-deploy",
+			Properties: resource.NewPropertyMapFromMap(map[string]any{
+				"metadata": map[string]any{
+					"name":   "bad-deploy",
+					"labels": map[string]any{},
+				},
+				"spec": map[string]any{
+					"replicas": float64(1),
+				},
+			}),
+			Options: plugin.AnalyzerResourceOptions{},
+		})
+		if err != nil {
+			t.Fatalf("Analyze failed: %v", err)
+		}
+		if len(resp.Diagnostics) == 0 {
+			t.Error("expected violation for missing app label")
+		}
+		found := false
+		for _, d := range resp.Diagnostics {
+			if d.Message != "" {
+				found = true
+			}
+		}
+		if !found {
+			t.Error("expected at least one diagnostic with a message")
+		}
+	})
+
+	t.Run("K8sResourceValid", func(t *testing.T) {
+		t.Parallel()
+		resp, err := a.Analyze(plugin.AnalyzerResource{
+			URN:  resource.URN("urn:pulumi:stack::proj::kubernetes:apps/v1:Deployment::good-deploy"),
+			Type: tokens.Type("kubernetes:apps/v1:Deployment"),
+			Name: "good-deploy",
+			Properties: resource.NewPropertyMapFromMap(map[string]any{
+				"metadata": map[string]any{
+					"name": "good-deploy",
+					"labels": map[string]any{
+						"app": "myapp",
+					},
+				},
+				"spec": map[string]any{
+					"replicas": float64(2),
+				},
+			}),
+			Options: plugin.AnalyzerResourceOptions{},
+		})
+		if err != nil {
+			t.Fatalf("Analyze failed: %v", err)
+		}
+		if len(resp.Diagnostics) != 0 {
+			t.Errorf("expected no violations for valid resource, got %d: %v",
+				len(resp.Diagnostics), resp.Diagnostics)
+		}
+	})
+
+	t.Run("NonK8sResourceSkipped", func(t *testing.T) {
+		t.Parallel()
+		resp, err := a.Analyze(plugin.AnalyzerResource{
+			URN:  resource.URN("urn:pulumi:stack::proj::aws:s3/bucket:Bucket::my-bucket"),
+			Type: tokens.Type("aws:s3/bucket:Bucket"),
+			Name: "my-bucket",
+			Properties: resource.NewPropertyMapFromMap(map[string]any{
+				"acl": "public-read",
+			}),
+			Options: plugin.AnalyzerResourceOptions{},
+		})
+		if err != nil {
+			t.Fatalf("Analyze failed: %v", err)
+		}
+		if len(resp.Diagnostics) != 0 {
+			t.Errorf("expected non-K8s resource to be skipped, got %d diagnostics", len(resp.Diagnostics))
+		}
+	})
+}

--- a/cmd/pulumi-analyzer-policy-opa/admission_integration_test.go
+++ b/cmd/pulumi-analyzer-policy-opa/admission_integration_test.go
@@ -156,3 +156,93 @@ func TestKubernetesAdmission_Integration(t *testing.T) {
 		}
 	})
 }
+
+// TestKubernetesAdmission_AnalyzeStack verifies stack-level evaluation with
+// kubernetes-admission format: non-K8s resources are filtered out before
+// evaluation, and Gatekeeper-style stack rules fire correctly.
+func TestKubernetesAdmission_AnalyzeStack(t *testing.T) {
+	t.Parallel()
+
+	// A stack-level Gatekeeper rule that counts deployments missing the "app" label.
+	module := `
+package test
+
+import rego.v1
+
+stack_violation contains {"msg": msg} if {
+    r := input.resources[_]
+    not r.review.object.metadata.labels["app"]
+    msg := sprintf("resource '%s' is missing required label: app", [r.review.name])
+}
+`
+	dir := t.TempDir()
+	manifest := "description: test\nruntime: opa\ninputFormat: kubernetes-admission\n"
+	if err := os.WriteFile(filepath.Join(dir, "PulumiPolicy.yaml"), []byte(manifest), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "policy.rego"), []byte(module), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	pack, e, err := loadPolicyPack(dir)
+	if err != nil {
+		t.Fatalf("loadPolicyPack failed: %v", err)
+	}
+
+	a := NewAnalyzer(pack, e)
+
+	resources := []plugin.AnalyzerStackResource{
+		{
+			AnalyzerResource: plugin.AnalyzerResource{
+				URN:  resource.URN("urn:pulumi:stack::proj::kubernetes:apps/v1:Deployment::bad-deploy"),
+				Type: tokens.Type("kubernetes:apps/v1:Deployment"),
+				Name: "bad-deploy",
+				Properties: resource.NewPropertyMapFromMap(map[string]any{
+					"metadata": map[string]any{
+						"name":   "bad-deploy",
+						"labels": map[string]any{},
+					},
+					"spec": map[string]any{"replicas": float64(1)},
+				}),
+			},
+		},
+		{
+			AnalyzerResource: plugin.AnalyzerResource{
+				URN:  resource.URN("urn:pulumi:stack::proj::kubernetes:apps/v1:Deployment::good-deploy"),
+				Type: tokens.Type("kubernetes:apps/v1:Deployment"),
+				Name: "good-deploy",
+				Properties: resource.NewPropertyMapFromMap(map[string]any{
+					"metadata": map[string]any{
+						"name":   "good-deploy",
+						"labels": map[string]any{"app": "web"},
+					},
+					"spec": map[string]any{"replicas": float64(2)},
+				}),
+			},
+		},
+		// Non-K8s resource — should be filtered out, not cause false positives.
+		{
+			AnalyzerResource: plugin.AnalyzerResource{
+				URN:  resource.URN("urn:pulumi:stack::proj::aws:s3/bucket:Bucket::my-bucket"),
+				Type: tokens.Type("aws:s3/bucket:Bucket"),
+				Name: "my-bucket",
+				Properties: resource.NewPropertyMapFromMap(map[string]any{
+					"acl": "private",
+				}),
+			},
+		},
+	}
+
+	resp, err := a.AnalyzeStack(resources)
+	if err != nil {
+		t.Fatalf("AnalyzeStack failed: %v", err)
+	}
+
+	// Only bad-deploy should violate; good-deploy has "app" label; AWS bucket is filtered.
+	if len(resp.Diagnostics) != 1 {
+		t.Fatalf("expected 1 violation, got %d: %v", len(resp.Diagnostics), resp.Diagnostics)
+	}
+	if resp.Diagnostics[0].Message != "resource 'bad-deploy' is missing required label: app" {
+		t.Errorf("unexpected message: %s", resp.Diagnostics[0].Message)
+	}
+}

--- a/cmd/pulumi-analyzer-policy-opa/analyzer.go
+++ b/cmd/pulumi-analyzer-policy-opa/analyzer.go
@@ -1,4 +1,4 @@
-// Copyright 2025, Pulumi Corporation.
+// Copyright 2026, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/pulumi-analyzer-policy-opa/analyzer.go
+++ b/cmd/pulumi-analyzer-policy-opa/analyzer.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/blang/semver"
 
@@ -56,12 +57,18 @@ func (a *analyzer) Name() tokens.QName {
 func (a *analyzer) Analyze(r plugin.AnalyzerResource) (plugin.AnalyzeResponse, error) {
 	a.warnMissingConfig()
 
-	// Build the enriched input object containing both resource properties and metadata
-	// (type, urn, name, options, provider) so that OPA policies can access the full context.
-	// TODO: to attain rule compatibility with OPA rules written for, say, the Kubernetes Admission
-	//     Controller, there is a very different schema we would need to follow. It's possible we should
-	//     make the schema translation pluggable and customizable for certain policy packs and/or providers.
-	obj := buildOPAInput(r)
+	var obj map[string]any
+	if a.pack.InputFormat == InputFormatKubernetesAdmission {
+		k8sInfo := parseK8sTypeToken(string(r.Type))
+		if k8sInfo == nil {
+			// Skip non-Kubernetes resources when admission format is active.
+			return plugin.AnalyzeResponse{}, nil
+		}
+		obj = buildKubernetesAdmissionInput(r, k8sInfo, a.policyConfig)
+	} else {
+		obj = buildOPAInput(r)
+	}
+
 	results, err := a.e.evalPolicyPack(context.Background(), a.pack, obj, resourceScope, a.policyConfig)
 	if err != nil {
 		return plugin.AnalyzeResponse{}, err
@@ -86,7 +93,12 @@ func (a *analyzer) AnalyzeStack(resources []plugin.AnalyzerStackResource) (plugi
 	}
 
 	// Build the stack-level input containing all resources.
-	obj := buildStackOPAInput(resources)
+	var obj map[string]any
+	if a.pack.InputFormat == InputFormatKubernetesAdmission {
+		obj = buildKubernetesAdmissionStackInput(resources)
+	} else {
+		obj = buildStackOPAInput(resources)
+	}
 	results, err := a.e.evalPolicyPack(context.Background(), a.pack, obj, stackScope, a.policyConfig)
 	if err != nil {
 		return plugin.AnalyzeResponse{}, err
@@ -243,6 +255,37 @@ func enforcementLevelToAPI(level enforcementLevel) apitype.EnforcementLevel {
 	}
 }
 
+// buildOptionsMap constructs the options map for a resource.
+func buildOptionsMap(r plugin.AnalyzerResource) map[string]any {
+	return map[string]any{
+		"protect":                 r.Options.Protect,
+		"ignoreChanges":           r.Options.IgnoreChanges,
+		"deleteBeforeReplace":     r.Options.DeleteBeforeReplace,
+		"additionalSecretOutputs": propertyKeysToStrings(r.Options.AdditionalSecretOutputs),
+		"aliasURNs":               aliasURNsToStrings(r.Options.AliasURNs),
+		"aliases":                 aliasesToMaps(r.Options.Aliases),
+		"customTimeouts": map[string]any{
+			"create": r.Options.CustomTimeouts.Create,
+			"update": r.Options.CustomTimeouts.Update,
+			"delete": r.Options.CustomTimeouts.Delete,
+		},
+		"parent": string(r.Options.Parent),
+	}
+}
+
+// buildProviderMap constructs the provider info map for a resource.
+func buildProviderMap(r plugin.AnalyzerResource) map[string]any {
+	if r.Provider != nil {
+		return map[string]any{
+			"type":       string(r.Provider.Type),
+			"name":       r.Provider.Name,
+			"urn":        string(r.Provider.URN),
+			"properties": r.Provider.Properties.Mappable(),
+		}
+	}
+	return map[string]any{}
+}
+
 // buildOPAInput constructs the input object passed to OPA policy evaluation.
 // It starts with the resource metadata fields (type, urn, __name, options, provider,
 // properties) and then overlays the resource's own properties on top so that Rego
@@ -261,36 +304,10 @@ func buildOPAInput(r plugin.AnalyzerResource) map[string]any {
 	obj["name"] = r.Name
 	obj["__name"] = r.Name
 
-	// Add resource options.
-	opts := map[string]any{
-		"protect":                 r.Options.Protect,
-		"ignoreChanges":           r.Options.IgnoreChanges,
-		"deleteBeforeReplace":     r.Options.DeleteBeforeReplace,
-		"additionalSecretOutputs": propertyKeysToStrings(r.Options.AdditionalSecretOutputs),
-		"aliasURNs":               aliasURNsToStrings(r.Options.AliasURNs),
-		"aliases":                 aliasesToMaps(r.Options.Aliases),
-		"customTimeouts": map[string]any{
-			"create": r.Options.CustomTimeouts.Create,
-			"update": r.Options.CustomTimeouts.Update,
-			"delete": r.Options.CustomTimeouts.Delete,
-		},
-		"parent": string(r.Options.Parent),
-	}
+	opts := buildOptionsMap(r)
 	obj["options"] = opts
 
-	// Add provider info. Use an empty map when provider is nil so that
-	// input.provider and input.__provider are always defined.
-	var providerInfo map[string]any
-	if r.Provider != nil {
-		providerInfo = map[string]any{
-			"type":       string(r.Provider.Type),
-			"name":       r.Provider.Name,
-			"urn":        string(r.Provider.URN),
-			"properties": r.Provider.Properties.Mappable(),
-		}
-	} else {
-		providerInfo = map[string]any{}
-	}
+	providerInfo := buildProviderMap(r)
 	obj["provider"] = providerInfo
 
 	// Expose the properties as a nested "properties" bag so that policies
@@ -316,6 +333,153 @@ func buildOPAInput(r plugin.AnalyzerResource) map[string]any {
 	obj["__provider"] = providerInfo
 
 	return obj
+}
+
+// k8sTypeInfo holds the parsed components of a Kubernetes Pulumi type token.
+type k8sTypeInfo struct {
+	Group   string
+	Version string
+	Kind    string
+}
+
+// apiVersion returns the Kubernetes apiVersion string (e.g. "apps/v1" or "v1" for core).
+func (k *k8sTypeInfo) apiVersion() string {
+	if k.Group == "" {
+		return k.Version
+	}
+	return k.Group + "/" + k.Version
+}
+
+// parseK8sTypeToken extracts group, version, and kind from a Pulumi Kubernetes type token.
+// Tokens have the form "kubernetes:<group>/<version>:<kind>" where the group for core
+// resources is "core". Returns nil if the token is not a Kubernetes resource type.
+func parseK8sTypeToken(typeToken string) *k8sTypeInfo {
+	if !strings.HasPrefix(typeToken, "kubernetes:") {
+		return nil
+	}
+
+	// Strip the "kubernetes:" prefix.
+	rest := typeToken[len("kubernetes:"):]
+
+	// Split into "<group>/<version>" and "<kind>".
+	parts := strings.SplitN(rest, ":", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return nil
+	}
+
+	kind := parts[1]
+	groupVersion := parts[0]
+
+	// Split group/version.
+	gvParts := strings.SplitN(groupVersion, "/", 2)
+	if len(gvParts) != 2 || gvParts[0] == "" || gvParts[1] == "" {
+		return nil
+	}
+
+	group := gvParts[0]
+	version := gvParts[1]
+
+	// "core" is Pulumi's representation of the empty API group.
+	if group == "core" {
+		group = ""
+	}
+
+	return &k8sTypeInfo{Group: group, Version: version, Kind: kind}
+}
+
+// buildKubernetesAdmissionInput constructs an input object compatible with OPA Gatekeeper
+// AdmissionReview rules. The structure mirrors what Gatekeeper passes to constraint templates:
+//
+//	input.review.object  — the Kubernetes resource object (properties + synthesized apiVersion/kind)
+//	input.review.kind    — GVK info {group, version, kind}
+//	input.review.name    — resource name from metadata
+//	input.review.namespace — namespace from metadata.namespace if present
+//	input.review.operation — always "CREATE" (Pulumi doesn't distinguish create/update in analyzer)
+//	input.parameters     — per-rule policy config (from policyConfig)
+//	input._pulumi        — escape hatch for Pulumi-specific metadata
+func buildKubernetesAdmissionInput(
+	r plugin.AnalyzerResource,
+	k8sInfo *k8sTypeInfo,
+	policyConfig map[string]plugin.AnalyzerPolicyConfig,
+) map[string]any {
+	props := r.Properties.Mappable()
+
+	// Build the review object — start with the resource properties.
+	reviewObject := make(map[string]any, len(props)+2)
+	for k, v := range props {
+		reviewObject[k] = v
+	}
+
+	// Synthesize apiVersion and kind if not already present in properties.
+	if _, ok := reviewObject["apiVersion"]; !ok {
+		reviewObject["apiVersion"] = k8sInfo.apiVersion()
+	}
+	if _, ok := reviewObject["kind"]; !ok {
+		reviewObject["kind"] = k8sInfo.Kind
+	}
+
+	// Extract name and namespace from metadata if available.
+	var name, namespace string
+	if md, ok := reviewObject["metadata"].(map[string]any); ok {
+		if n, ok := md["name"].(string); ok {
+			name = n
+		}
+		if ns, ok := md["namespace"].(string); ok {
+			namespace = ns
+		}
+	}
+	if name == "" {
+		name = r.Name
+	}
+
+	review := map[string]any{
+		"object": reviewObject,
+		"kind": map[string]any{
+			"group":   k8sInfo.Group,
+			"version": k8sInfo.Version,
+			"kind":    k8sInfo.Kind,
+		},
+		"name":      name,
+		"namespace": namespace,
+		"operation": "CREATE",
+	}
+
+	// Pulumi-specific metadata escape hatch.
+	pulumiMeta := map[string]any{
+		"type":     string(r.Type),
+		"urn":      string(r.URN),
+		"name":     r.Name,
+		"options":  buildOptionsMap(r),
+		"provider": buildProviderMap(r),
+	}
+
+	return map[string]any{
+		"review":  review,
+		"_pulumi": pulumiMeta,
+	}
+}
+
+// buildKubernetesAdmissionStackInput constructs the stack-level input for
+// kubernetes-admission format. Non-K8s resources are filtered out.
+func buildKubernetesAdmissionStackInput(resources []plugin.AnalyzerStackResource) map[string]any {
+	var resourceList []map[string]any
+
+	for _, sr := range resources {
+		k8sInfo := parseK8sTypeToken(string(sr.Type))
+		if k8sInfo == nil {
+			continue // skip non-K8s resources
+		}
+		obj := buildKubernetesAdmissionInput(sr.AnalyzerResource, k8sInfo, nil)
+		resourceList = append(resourceList, obj)
+	}
+
+	if resourceList == nil {
+		resourceList = make([]map[string]any, 0)
+	}
+
+	return map[string]any{
+		"resources": resourceList,
+	}
 }
 
 // buildStackOPAInput constructs the input object passed to OPA stack policy evaluation.

--- a/cmd/pulumi-analyzer-policy-opa/analyzer.go
+++ b/cmd/pulumi-analyzer-policy-opa/analyzer.go
@@ -64,7 +64,7 @@ func (a *analyzer) Analyze(r plugin.AnalyzerResource) (plugin.AnalyzeResponse, e
 			// Skip non-Kubernetes resources when admission format is active.
 			return plugin.AnalyzeResponse{}, nil
 		}
-		obj = buildKubernetesAdmissionInput(r, k8sInfo, a.policyConfig)
+		obj = buildKubernetesAdmissionInput(r, k8sInfo)
 	} else {
 		obj = buildOPAInput(r)
 	}
@@ -395,12 +395,10 @@ func parseK8sTypeToken(typeToken string) *k8sTypeInfo {
 //	input.review.name    — resource name from metadata
 //	input.review.namespace — namespace from metadata.namespace if present
 //	input.review.operation — always "CREATE" (Pulumi doesn't distinguish create/update in analyzer)
-//	input.parameters     — per-rule policy config (from policyConfig)
 //	input._pulumi        — escape hatch for Pulumi-specific metadata
 func buildKubernetesAdmissionInput(
 	r plugin.AnalyzerResource,
 	k8sInfo *k8sTypeInfo,
-	policyConfig map[string]plugin.AnalyzerPolicyConfig,
 ) map[string]any {
 	props := r.Properties.Mappable()
 
@@ -469,7 +467,7 @@ func buildKubernetesAdmissionStackInput(resources []plugin.AnalyzerStackResource
 		if k8sInfo == nil {
 			continue // skip non-K8s resources
 		}
-		obj := buildKubernetesAdmissionInput(sr.AnalyzerResource, k8sInfo, nil)
+		obj := buildKubernetesAdmissionInput(sr.AnalyzerResource, k8sInfo)
 		resourceList = append(resourceList, obj)
 	}
 

--- a/cmd/pulumi-analyzer-policy-opa/analyzer_integration_test.go
+++ b/cmd/pulumi-analyzer-policy-opa/analyzer_integration_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025, Pulumi Corporation.
+// Copyright 2026, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/pulumi-analyzer-policy-opa/analyzer_test.go
+++ b/cmd/pulumi-analyzer-policy-opa/analyzer_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025, Pulumi Corporation.
+// Copyright 2026, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/pulumi-analyzer-policy-opa/analyzer_test.go
+++ b/cmd/pulumi-analyzer-policy-opa/analyzer_test.go
@@ -741,7 +741,7 @@ func TestBuildKubernetesAdmissionInput(t *testing.T) {
 		})
 
 		k8sInfo := parseK8sTypeToken(string(r.Type))
-		input := buildKubernetesAdmissionInput(r, k8sInfo, nil)
+		input := buildKubernetesAdmissionInput(r, k8sInfo)
 
 		review, ok := input["review"].(map[string]any)
 		if !ok {
@@ -812,7 +812,7 @@ func TestBuildKubernetesAdmissionInput(t *testing.T) {
 		})
 
 		k8sInfo := parseK8sTypeToken(string(r.Type))
-		input := buildKubernetesAdmissionInput(r, k8sInfo, nil)
+		input := buildKubernetesAdmissionInput(r, k8sInfo)
 		review := input["review"].(map[string]any)
 		obj := review["object"].(map[string]any)
 
@@ -834,7 +834,7 @@ func TestBuildKubernetesAdmissionInput(t *testing.T) {
 		})
 
 		k8sInfo := parseK8sTypeToken(string(r.Type))
-		input := buildKubernetesAdmissionInput(r, k8sInfo, nil)
+		input := buildKubernetesAdmissionInput(r, k8sInfo)
 		review := input["review"].(map[string]any)
 
 		// Name should fall back to r.Name when metadata is absent.
@@ -855,7 +855,7 @@ func TestBuildKubernetesAdmissionInput(t *testing.T) {
 		})
 
 		k8sInfo := parseK8sTypeToken(string(r.Type))
-		input := buildKubernetesAdmissionInput(r, k8sInfo, nil)
+		input := buildKubernetesAdmissionInput(r, k8sInfo)
 		review := input["review"].(map[string]any)
 		obj := review["object"].(map[string]any)
 

--- a/cmd/pulumi-analyzer-policy-opa/analyzer_test.go
+++ b/cmd/pulumi-analyzer-policy-opa/analyzer_test.go
@@ -609,3 +609,305 @@ func TestBuildStackInput(t *testing.T) {
 		}
 	})
 }
+
+func TestParseK8sTypeToken(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		token   string
+		want    *k8sTypeInfo
+	}{
+		{
+			name:  "apps/v1 Deployment",
+			token: "kubernetes:apps/v1:Deployment",
+			want:  &k8sTypeInfo{Group: "apps", Version: "v1", Kind: "Deployment"},
+		},
+		{
+			name:  "core/v1 Pod (core maps to empty group)",
+			token: "kubernetes:core/v1:Pod",
+			want:  &k8sTypeInfo{Group: "", Version: "v1", Kind: "Pod"},
+		},
+		{
+			name:  "networking.k8s.io/v1 NetworkPolicy",
+			token: "kubernetes:networking.k8s.io/v1:NetworkPolicy",
+			want:  &k8sTypeInfo{Group: "networking.k8s.io", Version: "v1", Kind: "NetworkPolicy"},
+		},
+		{
+			name:  "batch/v1 Job",
+			token: "kubernetes:batch/v1:Job",
+			want:  &k8sTypeInfo{Group: "batch", Version: "v1", Kind: "Job"},
+		},
+		{
+			name:  "non-K8s AWS type",
+			token: "aws:s3/bucket:Bucket",
+			want:  nil,
+		},
+		{
+			name:  "non-K8s Azure type",
+			token: "azure:storage/account:Account",
+			want:  nil,
+		},
+		{
+			name:  "empty string",
+			token: "",
+			want:  nil,
+		},
+		{
+			name:  "malformed - no kind separator",
+			token: "kubernetes:apps/v1",
+			want:  nil,
+		},
+		{
+			name:  "malformed - no version",
+			token: "kubernetes:apps:Deployment",
+			want:  nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := parseK8sTypeToken(tc.token)
+			if tc.want == nil {
+				if got != nil {
+					t.Errorf("expected nil, got %+v", got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatalf("expected %+v, got nil", tc.want)
+			}
+			if got.Group != tc.want.Group {
+				t.Errorf("Group: expected %q, got %q", tc.want.Group, got.Group)
+			}
+			if got.Version != tc.want.Version {
+				t.Errorf("Version: expected %q, got %q", tc.want.Version, got.Version)
+			}
+			if got.Kind != tc.want.Kind {
+				t.Errorf("Kind: expected %q, got %q", tc.want.Kind, got.Kind)
+			}
+		})
+	}
+}
+
+func TestK8sTypeInfo_ApiVersion(t *testing.T) {
+	t.Parallel()
+
+	t.Run("WithGroup", func(t *testing.T) {
+		t.Parallel()
+		info := &k8sTypeInfo{Group: "apps", Version: "v1", Kind: "Deployment"}
+		if got := info.apiVersion(); got != "apps/v1" {
+			t.Errorf("expected apps/v1, got %s", got)
+		}
+	})
+
+	t.Run("CoreGroup", func(t *testing.T) {
+		t.Parallel()
+		info := &k8sTypeInfo{Group: "", Version: "v1", Kind: "Pod"}
+		if got := info.apiVersion(); got != "v1" {
+			t.Errorf("expected v1, got %s", got)
+		}
+	})
+}
+
+// makeK8sResource creates an AnalyzerResource for a Kubernetes type.
+func makeK8sResource(typeToken, name string, props map[string]any) plugin.AnalyzerResource {
+	return plugin.AnalyzerResource{
+		URN:        resource.URN("urn:pulumi:test-stack::test-project::" + typeToken + "::" + name),
+		Type:       tokens.Type(typeToken),
+		Name:       name,
+		Properties: resource.NewPropertyMapFromMap(props),
+		Options:    plugin.AnalyzerResourceOptions{},
+	}
+}
+
+func TestBuildKubernetesAdmissionInput(t *testing.T) {
+	t.Parallel()
+
+	t.Run("BasicDeployment", func(t *testing.T) {
+		t.Parallel()
+		r := makeK8sResource("kubernetes:apps/v1:Deployment", "my-deploy", map[string]any{
+			"metadata": map[string]any{
+				"name":      "my-deploy",
+				"namespace": "default",
+				"labels": map[string]any{
+					"app": "web",
+				},
+			},
+			"spec": map[string]any{
+				"replicas": float64(3),
+			},
+		})
+
+		k8sInfo := parseK8sTypeToken(string(r.Type))
+		input := buildKubernetesAdmissionInput(r, k8sInfo, nil)
+
+		review, ok := input["review"].(map[string]any)
+		if !ok {
+			t.Fatal("expected review to be a map")
+		}
+
+		// Check review.object has properties + synthesized fields.
+		obj, ok := review["object"].(map[string]any)
+		if !ok {
+			t.Fatal("expected review.object to be a map")
+		}
+		if obj["apiVersion"] != "apps/v1" {
+			t.Errorf("expected apiVersion = apps/v1, got %v", obj["apiVersion"])
+		}
+		if obj["kind"] != "Deployment" {
+			t.Errorf("expected kind = Deployment, got %v", obj["kind"])
+		}
+		if obj["spec"] == nil {
+			t.Error("expected spec to be present")
+		}
+
+		// Check review.kind GVK.
+		kind, ok := review["kind"].(map[string]any)
+		if !ok {
+			t.Fatal("expected review.kind to be a map")
+		}
+		if kind["group"] != "apps" {
+			t.Errorf("expected group = apps, got %v", kind["group"])
+		}
+		if kind["version"] != "v1" {
+			t.Errorf("expected version = v1, got %v", kind["version"])
+		}
+		if kind["kind"] != "Deployment" {
+			t.Errorf("expected kind = Deployment, got %v", kind["kind"])
+		}
+
+		// Check review.name and review.namespace.
+		if review["name"] != "my-deploy" {
+			t.Errorf("expected name = my-deploy, got %v", review["name"])
+		}
+		if review["namespace"] != "default" {
+			t.Errorf("expected namespace = default, got %v", review["namespace"])
+		}
+		if review["operation"] != "CREATE" {
+			t.Errorf("expected operation = CREATE, got %v", review["operation"])
+		}
+
+		// Check _pulumi metadata.
+		pulumi, ok := input["_pulumi"].(map[string]any)
+		if !ok {
+			t.Fatal("expected _pulumi to be a map")
+		}
+		if pulumi["type"] != "kubernetes:apps/v1:Deployment" {
+			t.Errorf("expected _pulumi.type, got %v", pulumi["type"])
+		}
+		if pulumi["name"] != "my-deploy" {
+			t.Errorf("expected _pulumi.name = my-deploy, got %v", pulumi["name"])
+		}
+	})
+
+	t.Run("CoreGroupPod", func(t *testing.T) {
+		t.Parallel()
+		r := makeK8sResource("kubernetes:core/v1:Pod", "my-pod", map[string]any{
+			"metadata": map[string]any{
+				"name": "my-pod",
+			},
+			"spec": map[string]any{},
+		})
+
+		k8sInfo := parseK8sTypeToken(string(r.Type))
+		input := buildKubernetesAdmissionInput(r, k8sInfo, nil)
+		review := input["review"].(map[string]any)
+		obj := review["object"].(map[string]any)
+
+		// Core group should produce apiVersion "v1" (no group prefix).
+		if obj["apiVersion"] != "v1" {
+			t.Errorf("expected apiVersion = v1, got %v", obj["apiVersion"])
+		}
+
+		kind := review["kind"].(map[string]any)
+		if kind["group"] != "" {
+			t.Errorf("expected empty group for core, got %v", kind["group"])
+		}
+	})
+
+	t.Run("NoMetadata", func(t *testing.T) {
+		t.Parallel()
+		r := makeK8sResource("kubernetes:core/v1:ConfigMap", "my-cm", map[string]any{
+			"data": map[string]any{"key": "value"},
+		})
+
+		k8sInfo := parseK8sTypeToken(string(r.Type))
+		input := buildKubernetesAdmissionInput(r, k8sInfo, nil)
+		review := input["review"].(map[string]any)
+
+		// Name should fall back to r.Name when metadata is absent.
+		if review["name"] != "my-cm" {
+			t.Errorf("expected name = my-cm, got %v", review["name"])
+		}
+		if review["namespace"] != "" {
+			t.Errorf("expected empty namespace, got %v", review["namespace"])
+		}
+	})
+
+	t.Run("ExistingApiVersionPreserved", func(t *testing.T) {
+		t.Parallel()
+		r := makeK8sResource("kubernetes:apps/v1:Deployment", "my-deploy", map[string]any{
+			"apiVersion": "apps/v1",
+			"kind":       "Deployment",
+			"metadata":   map[string]any{"name": "my-deploy"},
+		})
+
+		k8sInfo := parseK8sTypeToken(string(r.Type))
+		input := buildKubernetesAdmissionInput(r, k8sInfo, nil)
+		review := input["review"].(map[string]any)
+		obj := review["object"].(map[string]any)
+
+		// Should preserve existing values, not overwrite.
+		if obj["apiVersion"] != "apps/v1" {
+			t.Errorf("expected apiVersion preserved, got %v", obj["apiVersion"])
+		}
+		if obj["kind"] != "Deployment" {
+			t.Errorf("expected kind preserved, got %v", obj["kind"])
+		}
+	})
+}
+
+func TestBuildKubernetesAdmissionStackInput(t *testing.T) {
+	t.Parallel()
+
+	t.Run("FiltersNonK8s", func(t *testing.T) {
+		t.Parallel()
+		resources := []plugin.AnalyzerStackResource{
+			{AnalyzerResource: makeK8sResource("kubernetes:apps/v1:Deployment", "deploy", map[string]any{
+				"metadata": map[string]any{"name": "deploy"},
+			})},
+			{AnalyzerResource: makeK8sResource("aws:s3/bucket:Bucket", "bucket", map[string]any{
+				"acl": "private",
+			})},
+		}
+
+		input := buildKubernetesAdmissionStackInput(resources)
+		resList, ok := input["resources"].([]map[string]any)
+		if !ok {
+			t.Fatal("expected resources to be []map[string]any")
+		}
+		if len(resList) != 1 {
+			t.Fatalf("expected 1 resource (non-K8s filtered), got %d", len(resList))
+		}
+
+		// The remaining resource should have admission format.
+		if _, ok := resList[0]["review"]; !ok {
+			t.Error("expected admission-format resource with review key")
+		}
+	})
+
+	t.Run("EmptyWhenAllNonK8s", func(t *testing.T) {
+		t.Parallel()
+		resources := []plugin.AnalyzerStackResource{
+			{AnalyzerResource: makeK8sResource("aws:s3/bucket:Bucket", "bucket", map[string]any{})},
+		}
+
+		input := buildKubernetesAdmissionStackInput(resources)
+		resList := input["resources"].([]map[string]any)
+		if len(resList) != 0 {
+			t.Errorf("expected 0 resources, got %d", len(resList))
+		}
+	})
+}

--- a/cmd/pulumi-analyzer-policy-opa/config_test.go
+++ b/cmd/pulumi-analyzer-policy-opa/config_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025, Pulumi Corporation.
+// Copyright 2026, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/pulumi-analyzer-policy-opa/eval.go
+++ b/cmd/pulumi-analyzer-policy-opa/eval.go
@@ -1,4 +1,4 @@
-// Copyright 2025, Pulumi Corporation.
+// Copyright 2026, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/pulumi-analyzer-policy-opa/eval.go
+++ b/cmd/pulumi-analyzer-policy-opa/eval.go
@@ -55,11 +55,22 @@ func (e *evaler) evalPolicyPack(
 			continue
 		}
 
+		// When kubernetes-admission format is active, inject input.parameters
+		// from the per-rule policy config so Gatekeeper rules can access them.
+		evalInput := input
+		if pack.InputFormat == InputFormatKubernetesAdmission {
+			if policyConfig != nil {
+				if cfg, ok := policyConfig[rule.Name]; ok && len(cfg.Properties) > 0 {
+					evalInput = cloneInputWithParameters(input, cfg.Properties)
+				}
+			}
+		}
+
 		// Build a rego object that can be evaluated.
 		opts := []func(*rego.Rego){
 			rego.Query(fmt.Sprintf("data.%s.%s", pack.Name, rule.Name)),
 			rego.Compiler(e.c),
-			rego.Input(input),
+			rego.Input(evalInput),
 			rego.SetRegoVersion(ast.RegoV0),
 		}
 		if store != nil {
@@ -76,10 +87,7 @@ func (e *evaler) evalPolicyPack(
 			for _, expr := range result.Expressions {
 				if ae, ok := expr.Value.([]any); ok && len(ae) > 0 {
 					for _, v := range ae {
-						msg, ok := v.(string)
-						if !ok {
-							msg = fmt.Sprintf("%v", v)
-						}
+						msg := extractViolationMessage(v)
 						results = append(results, evalPolicyResult{
 							pack:  pack.Name,
 							rule:  rule.Name,
@@ -125,6 +133,39 @@ type evalPolicyResult struct {
 	rule  string
 	msg   string
 	level enforcementLevel
+}
+
+// extractViolationMessage extracts a human-readable message from an OPA rule result value.
+// Gatekeeper rules return violation[{"msg": msg, ...}] (map values), while standard
+// rules return deny["message string"]. This handles both formats.
+func extractViolationMessage(v any) string {
+	switch val := v.(type) {
+	case string:
+		return val
+	case map[string]any:
+		if msg, ok := val["msg"].(string); ok {
+			return msg
+		}
+		return fmt.Sprintf("%v", val)
+	default:
+		return fmt.Sprintf("%v", v)
+	}
+}
+
+// cloneInputWithParameters creates a shallow copy of the input map and injects
+// a "parameters" key containing the given properties. This lets Gatekeeper-style
+// rules access per-rule config via input.parameters.
+func cloneInputWithParameters(input any, parameters map[string]any) any {
+	m, ok := input.(map[string]any)
+	if !ok {
+		return input
+	}
+	clone := make(map[string]any, len(m)+1)
+	for k, v := range m {
+		clone[k] = v
+	}
+	clone["parameters"] = parameters
+	return clone
 }
 
 // configuredEnforcementLevel returns the enforcement level override for a policy

--- a/cmd/pulumi-analyzer-policy-opa/eval_test.go
+++ b/cmd/pulumi-analyzer-policy-opa/eval_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025, Pulumi Corporation.
+// Copyright 2026, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/pulumi-analyzer-policy-opa/eval_test.go
+++ b/cmd/pulumi-analyzer-policy-opa/eval_test.go
@@ -663,13 +663,122 @@ stack_deny[msg] {
 	})
 }
 
-func TestEval_GatekeeperViolationMap(t *testing.T) {
+func TestExtractViolationMessage(t *testing.T) {
 	t.Parallel()
+
+	t.Run("String", func(t *testing.T) {
+		t.Parallel()
+		msg := extractViolationMessage("plain string")
+		if msg != "plain string" {
+			t.Errorf("expected 'plain string', got %q", msg)
+		}
+	})
 
 	t.Run("MapWithMsg", func(t *testing.T) {
 		t.Parallel()
-		// Gatekeeper-style violation rule returning a set of maps with "msg" key.
-		module := `
+		msg := extractViolationMessage(map[string]any{"msg": "violation found", "details": map[string]any{}})
+		if msg != "violation found" {
+			t.Errorf("expected 'violation found', got %q", msg)
+		}
+	})
+
+	t.Run("MapWithoutMsg", func(t *testing.T) {
+		t.Parallel()
+		msg := extractViolationMessage(map[string]any{"details": "something"})
+		if msg == "" {
+			t.Error("expected non-empty message for map without msg key")
+		}
+	})
+
+	t.Run("MapWithNonStringMsg", func(t *testing.T) {
+		t.Parallel()
+		// msg key exists but is not a string — should fall back to fmt.Sprintf.
+		msg := extractViolationMessage(map[string]any{"msg": 42})
+		if msg == "" {
+			t.Error("expected non-empty message for non-string msg")
+		}
+	})
+
+	t.Run("Integer", func(t *testing.T) {
+		t.Parallel()
+		msg := extractViolationMessage(42)
+		if msg != "42" {
+			t.Errorf("expected '42', got %q", msg)
+		}
+	})
+
+	t.Run("Bool", func(t *testing.T) {
+		t.Parallel()
+		msg := extractViolationMessage(true)
+		if msg != "true" {
+			t.Errorf("expected 'true', got %q", msg)
+		}
+	})
+}
+
+func TestCloneInputWithParameters(t *testing.T) {
+	t.Parallel()
+
+	t.Run("MapInput", func(t *testing.T) {
+		t.Parallel()
+		input := map[string]any{
+			"review": map[string]any{"object": map[string]any{}},
+		}
+		params := map[string]any{"maxReplicas": float64(3)}
+
+		result := cloneInputWithParameters(input, params)
+
+		m, ok := result.(map[string]any)
+		if !ok {
+			t.Fatal("expected result to be a map")
+		}
+
+		// Original input should not be modified.
+		if _, exists := input["parameters"]; exists {
+			t.Error("original input should not be modified")
+		}
+
+		// Clone should have parameters.
+		p, ok := m["parameters"].(map[string]any)
+		if !ok {
+			t.Fatal("expected parameters in clone")
+		}
+		if p["maxReplicas"] != float64(3) {
+			t.Errorf("expected maxReplicas=3, got %v", p["maxReplicas"])
+		}
+
+		// Clone should preserve existing keys.
+		if _, ok := m["review"]; !ok {
+			t.Error("expected review key preserved in clone")
+		}
+	})
+
+	t.Run("NonMapInput", func(t *testing.T) {
+		t.Parallel()
+		input := "not a map"
+		params := map[string]any{"key": "value"}
+
+		result := cloneInputWithParameters(input, params)
+		if result != "not a map" {
+			t.Errorf("expected non-map input returned unchanged, got %v", result)
+		}
+	})
+
+	t.Run("NilInput", func(t *testing.T) {
+		t.Parallel()
+		params := map[string]any{"key": "value"}
+		result := cloneInputWithParameters(nil, params)
+		if result != nil {
+			t.Errorf("expected nil returned for nil input, got %v", result)
+		}
+	})
+}
+
+func TestEval_GatekeeperViolationMap(t *testing.T) {
+	t.Parallel()
+
+	// End-to-end test: Gatekeeper-style violation rule through the eval pipeline.
+	module := `
 package test
 
 import rego.v1
@@ -679,62 +788,47 @@ violation contains {"msg": msg} if {
     msg := "missing required label: app"
 }
 `
-		compiler := compileModule(t, "test", module)
-		e := &evaler{c: compiler}
+	compiler := compileModule(t, "test", module)
+	e := &evaler{c: compiler}
 
-		pack := &policyPack{
-			Name: "test",
-			Policies: []*policyRule{
-				{Name: "violation", Level: mandatoryRule, Scope: resourceScope},
-			},
-		}
+	pack := &policyPack{
+		Name: "test",
+		Policies: []*policyRule{
+			{Name: "violation", Level: mandatoryRule, Scope: resourceScope},
+		},
+	}
 
-		input := map[string]any{
-			"review": map[string]any{
-				"object": map[string]any{
-					"metadata": map[string]any{
-						"labels": map[string]any{},
-					},
+	input := map[string]any{
+		"review": map[string]any{
+			"object": map[string]any{
+				"metadata": map[string]any{
+					"labels": map[string]any{},
 				},
 			},
-		}
+		},
+	}
 
-		results, err := e.evalPolicyPack(context.Background(), pack, input, resourceScope, nil)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
+	results, err := e.evalPolicyPack(context.Background(), pack, input, resourceScope, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
-		if len(results) != 1 {
-			t.Fatalf("expected 1 result, got %d", len(results))
-		}
-		if results[0].msg != "missing required label: app" {
-			t.Errorf("expected violation message, got %q", results[0].msg)
-		}
-	})
-
-	t.Run("MapWithoutMsg", func(t *testing.T) {
-		t.Parallel()
-		// A map without "msg" should fall back to fmt.Sprintf.
-		msg := extractViolationMessage(map[string]any{"details": "something"})
-		if msg == "" {
-			t.Error("expected non-empty message for map without msg key")
-		}
-	})
-
-	t.Run("StringValue", func(t *testing.T) {
-		t.Parallel()
-		msg := extractViolationMessage("plain string")
-		if msg != "plain string" {
-			t.Errorf("expected 'plain string', got %q", msg)
-		}
-	})
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].msg != "missing required label: app" {
+		t.Errorf("expected violation message, got %q", results[0].msg)
+	}
 }
 
 func TestEval_InputParameters(t *testing.T) {
 	t.Parallel()
 
-	// Gatekeeper-style rule accessing input.parameters.
-	module := `
+	t.Run("Injected", func(t *testing.T) {
+		t.Parallel()
+
+		// Gatekeeper-style rule accessing input.parameters.
+		module := `
 package test
 
 import rego.v1
@@ -745,50 +839,231 @@ violation contains {"msg": msg} if {
     msg := sprintf("replicas %d exceeds max %d", [input.review.object.spec.replicas, max])
 }
 `
-	dir := writeRegoFile(t, "policy.rego", module)
-	pack, e, err := loadPolicyPack(dir)
-	if err != nil {
-		t.Fatalf("loadPolicyPack failed: %v", err)
-	}
-	pack.InputFormat = InputFormatKubernetesAdmission
+		dir := writeRegoFile(t, "policy.rego", module)
+		pack, e, err := loadPolicyPack(dir)
+		if err != nil {
+			t.Fatalf("loadPolicyPack failed: %v", err)
+		}
+		pack.InputFormat = InputFormatKubernetesAdmission
 
-	config := map[string]plugin.AnalyzerPolicyConfig{
-		"violation": {
-			Properties: map[string]any{
-				"maxReplicas": float64(3),
-			},
-		},
-	}
-
-	// Input with replicas=5 should violate.
-	input := map[string]any{
-		"review": map[string]any{
-			"object": map[string]any{
-				"spec": map[string]any{
-					"replicas": float64(5),
+		config := map[string]plugin.AnalyzerPolicyConfig{
+			"violation": {
+				Properties: map[string]any{
+					"maxReplicas": float64(3),
 				},
 			},
-		},
-	}
+		}
 
-	results, err := e.evalPolicyPack(context.Background(), pack, input, resourceScope, config)
-	if err != nil {
-		t.Fatalf("evalPolicyPack failed: %v", err)
-	}
-	if len(results) != 1 {
-		t.Fatalf("expected 1 violation, got %d", len(results))
-	}
-	if results[0].msg != "replicas 5 exceeds max 3" {
-		t.Errorf("unexpected message: %s", results[0].msg)
-	}
+		// Input with replicas=5 should violate.
+		input := map[string]any{
+			"review": map[string]any{
+				"object": map[string]any{
+					"spec": map[string]any{
+						"replicas": float64(5),
+					},
+				},
+			},
+		}
 
-	// Input with replicas=2 should pass.
-	input["review"].(map[string]any)["object"].(map[string]any)["spec"].(map[string]any)["replicas"] = float64(2)
-	results, err = e.evalPolicyPack(context.Background(), pack, input, resourceScope, config)
-	if err != nil {
-		t.Fatalf("evalPolicyPack failed: %v", err)
-	}
-	if len(results) != 0 {
-		t.Errorf("expected 0 violations, got %d", len(results))
-	}
+		results, err := e.evalPolicyPack(context.Background(), pack, input, resourceScope, config)
+		if err != nil {
+			t.Fatalf("evalPolicyPack failed: %v", err)
+		}
+		if len(results) != 1 {
+			t.Fatalf("expected 1 violation, got %d", len(results))
+		}
+		if results[0].msg != "replicas 5 exceeds max 3" {
+			t.Errorf("unexpected message: %s", results[0].msg)
+		}
+
+		// Input with replicas=2 should pass.
+		input = map[string]any{
+			"review": map[string]any{
+				"object": map[string]any{
+					"spec": map[string]any{
+						"replicas": float64(2),
+					},
+				},
+			},
+		}
+		results, err = e.evalPolicyPack(context.Background(), pack, input, resourceScope, config)
+		if err != nil {
+			t.Fatalf("evalPolicyPack failed: %v", err)
+		}
+		if len(results) != 0 {
+			t.Errorf("expected 0 violations, got %d", len(results))
+		}
+	})
+
+	t.Run("NotInjectedWhenNonAdmissionFormat", func(t *testing.T) {
+		t.Parallel()
+
+		// Rule references input.parameters but pack is NOT kubernetes-admission.
+		// Parameters should NOT be injected, so the rule should not fire.
+		module := `
+package test
+
+import rego.v1
+
+violation contains {"msg": msg} if {
+    max := input.parameters.maxReplicas
+    input.replicas > max
+    msg := "too many replicas"
+}
+`
+		dir := writeRegoFile(t, "policy.rego", module)
+		pack, e, err := loadPolicyPack(dir)
+		if err != nil {
+			t.Fatalf("loadPolicyPack failed: %v", err)
+		}
+		// InputFormat is "" (default) — parameters should NOT be injected.
+
+		config := map[string]plugin.AnalyzerPolicyConfig{
+			"violation": {
+				Properties: map[string]any{
+					"maxReplicas": float64(3),
+				},
+			},
+		}
+
+		input := map[string]any{"replicas": float64(5)}
+		results, err := e.evalPolicyPack(context.Background(), pack, input, resourceScope, config)
+		if err != nil {
+			t.Fatalf("evalPolicyPack failed: %v", err)
+		}
+		// Rule should not fire because input.parameters is undefined (not injected).
+		if len(results) != 0 {
+			t.Errorf("expected 0 violations (parameters not injected without admission format), got %d", len(results))
+		}
+	})
+
+	t.Run("NotInjectedWhenRuleNotInConfig", func(t *testing.T) {
+		t.Parallel()
+
+		// Admission format is active, but the rule has no config entry.
+		// Parameters should not be injected, so rule should not fire.
+		module := `
+package test
+
+import rego.v1
+
+violation contains {"msg": msg} if {
+    max := input.parameters.maxReplicas
+    input.review.object.spec.replicas > max
+    msg := "too many replicas"
+}
+`
+		dir := writeRegoFile(t, "policy.rego", module)
+		pack, e, err := loadPolicyPack(dir)
+		if err != nil {
+			t.Fatalf("loadPolicyPack failed: %v", err)
+		}
+		pack.InputFormat = InputFormatKubernetesAdmission
+
+		// Config exists but has no entry for "violation".
+		config := map[string]plugin.AnalyzerPolicyConfig{
+			"other_rule": {
+				Properties: map[string]any{"maxReplicas": float64(3)},
+			},
+		}
+
+		input := map[string]any{
+			"review": map[string]any{
+				"object": map[string]any{
+					"spec": map[string]any{"replicas": float64(5)},
+				},
+			},
+		}
+		results, err := e.evalPolicyPack(context.Background(), pack, input, resourceScope, config)
+		if err != nil {
+			t.Fatalf("evalPolicyPack failed: %v", err)
+		}
+		if len(results) != 0 {
+			t.Errorf("expected 0 violations (no config for this rule), got %d", len(results))
+		}
+	})
+
+	t.Run("NotInjectedWhenPropertiesEmpty", func(t *testing.T) {
+		t.Parallel()
+
+		// Admission format active, rule has config entry but Properties is empty.
+		module := `
+package test
+
+import rego.v1
+
+violation contains {"msg": msg} if {
+    max := input.parameters.maxReplicas
+    input.review.object.spec.replicas > max
+    msg := "too many replicas"
+}
+`
+		dir := writeRegoFile(t, "policy.rego", module)
+		pack, e, err := loadPolicyPack(dir)
+		if err != nil {
+			t.Fatalf("loadPolicyPack failed: %v", err)
+		}
+		pack.InputFormat = InputFormatKubernetesAdmission
+
+		config := map[string]plugin.AnalyzerPolicyConfig{
+			"violation": {
+				Properties: map[string]any{},
+			},
+		}
+
+		input := map[string]any{
+			"review": map[string]any{
+				"object": map[string]any{
+					"spec": map[string]any{"replicas": float64(5)},
+				},
+			},
+		}
+		results, err := e.evalPolicyPack(context.Background(), pack, input, resourceScope, config)
+		if err != nil {
+			t.Fatalf("evalPolicyPack failed: %v", err)
+		}
+		if len(results) != 0 {
+			t.Errorf("expected 0 violations (empty properties), got %d", len(results))
+		}
+	})
+
+	t.Run("NilPolicyConfig", func(t *testing.T) {
+		t.Parallel()
+
+		// Admission format active but policyConfig is nil.
+		// Should not crash, parameters not injected.
+		module := `
+package test
+
+import rego.v1
+
+violation contains {"msg": msg} if {
+    not input.review.object.metadata.labels["app"]
+    msg := "no app label"
+}
+`
+		dir := writeRegoFile(t, "policy.rego", module)
+		pack, e, err := loadPolicyPack(dir)
+		if err != nil {
+			t.Fatalf("loadPolicyPack failed: %v", err)
+		}
+		pack.InputFormat = InputFormatKubernetesAdmission
+
+		input := map[string]any{
+			"review": map[string]any{
+				"object": map[string]any{
+					"metadata": map[string]any{
+						"labels": map[string]any{},
+					},
+				},
+			},
+		}
+		results, err := e.evalPolicyPack(context.Background(), pack, input, resourceScope, nil)
+		if err != nil {
+			t.Fatalf("evalPolicyPack failed: %v", err)
+		}
+		if len(results) != 1 {
+			t.Fatalf("expected 1 violation, got %d", len(results))
+		}
+	})
 }

--- a/cmd/pulumi-analyzer-policy-opa/eval_test.go
+++ b/cmd/pulumi-analyzer-policy-opa/eval_test.go
@@ -15,7 +15,6 @@
 package main
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
@@ -52,7 +51,7 @@ func evalRule(t *testing.T, compiler *ast.Compiler, pkg, ruleName string, input 
 		rego.SetRegoVersion(ast.RegoV0),
 	)
 
-	rs, err := query.Eval(context.Background())
+	rs, err := query.Eval(t.Context())
 	if err != nil {
 		t.Fatalf("evaluation failed: %v", err)
 	}
@@ -334,7 +333,7 @@ deny contains val if {
 			},
 		}
 
-		results, err := e.evalPolicyPack(context.Background(), pack, map[string]any{}, resourceScope, nil)
+		results, err := e.evalPolicyPack(t.Context(), pack, map[string]any{}, resourceScope, nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -615,7 +614,7 @@ stack_deny[msg] {
 
 		// Evaluate with stack scope — should only get stack violations.
 		input := map[string]any{"resources": []any{}}
-		results, err := e.evalPolicyPack(context.Background(), pack, input, stackScope, nil)
+		results, err := e.evalPolicyPack(t.Context(), pack, input, stackScope, nil)
 		if err != nil {
 			t.Fatalf("evalPolicyPack failed: %v", err)
 		}
@@ -649,7 +648,7 @@ stack_deny[msg] {
 
 		// Evaluate with resource scope — should only get resource violations.
 		input := map[string]any{"acl": "test"}
-		results, err := e.evalPolicyPack(context.Background(), pack, input, resourceScope, nil)
+		results, err := e.evalPolicyPack(t.Context(), pack, input, resourceScope, nil)
 		if err != nil {
 			t.Fatalf("evalPolicyPack failed: %v", err)
 		}
@@ -808,7 +807,7 @@ violation contains {"msg": msg} if {
 		},
 	}
 
-	results, err := e.evalPolicyPack(context.Background(), pack, input, resourceScope, nil)
+	results, err := e.evalPolicyPack(t.Context(), pack, input, resourceScope, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -865,7 +864,7 @@ violation contains {"msg": msg} if {
 			},
 		}
 
-		results, err := e.evalPolicyPack(context.Background(), pack, input, resourceScope, config)
+		results, err := e.evalPolicyPack(t.Context(), pack, input, resourceScope, config)
 		if err != nil {
 			t.Fatalf("evalPolicyPack failed: %v", err)
 		}
@@ -886,7 +885,7 @@ violation contains {"msg": msg} if {
 				},
 			},
 		}
-		results, err = e.evalPolicyPack(context.Background(), pack, input, resourceScope, config)
+		results, err = e.evalPolicyPack(t.Context(), pack, input, resourceScope, config)
 		if err != nil {
 			t.Fatalf("evalPolicyPack failed: %v", err)
 		}
@@ -927,7 +926,7 @@ violation contains {"msg": msg} if {
 		}
 
 		input := map[string]any{"replicas": float64(5)}
-		results, err := e.evalPolicyPack(context.Background(), pack, input, resourceScope, config)
+		results, err := e.evalPolicyPack(t.Context(), pack, input, resourceScope, config)
 		if err != nil {
 			t.Fatalf("evalPolicyPack failed: %v", err)
 		}
@@ -974,7 +973,7 @@ violation contains {"msg": msg} if {
 				},
 			},
 		}
-		results, err := e.evalPolicyPack(context.Background(), pack, input, resourceScope, config)
+		results, err := e.evalPolicyPack(t.Context(), pack, input, resourceScope, config)
 		if err != nil {
 			t.Fatalf("evalPolicyPack failed: %v", err)
 		}
@@ -1018,7 +1017,7 @@ violation contains {"msg": msg} if {
 				},
 			},
 		}
-		results, err := e.evalPolicyPack(context.Background(), pack, input, resourceScope, config)
+		results, err := e.evalPolicyPack(t.Context(), pack, input, resourceScope, config)
 		if err != nil {
 			t.Fatalf("evalPolicyPack failed: %v", err)
 		}
@@ -1058,7 +1057,7 @@ violation contains {"msg": msg} if {
 				},
 			},
 		}
-		results, err := e.evalPolicyPack(context.Background(), pack, input, resourceScope, nil)
+		results, err := e.evalPolicyPack(t.Context(), pack, input, resourceScope, nil)
 		if err != nil {
 			t.Fatalf("evalPolicyPack failed: %v", err)
 		}

--- a/cmd/pulumi-analyzer-policy-opa/eval_test.go
+++ b/cmd/pulumi-analyzer-policy-opa/eval_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/open-policy-agent/opa/v1/ast"
 	"github.com/open-policy-agent/opa/v1/rego"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 )
 
 // compileModule compiles a single Rego module and returns the compiler.
@@ -660,4 +661,134 @@ stack_deny[msg] {
 			t.Errorf("expected 'resource violation', got %q", results[0].msg)
 		}
 	})
+}
+
+func TestEval_GatekeeperViolationMap(t *testing.T) {
+	t.Parallel()
+
+	t.Run("MapWithMsg", func(t *testing.T) {
+		t.Parallel()
+		// Gatekeeper-style violation rule returning a set of maps with "msg" key.
+		module := `
+package test
+
+import rego.v1
+
+violation contains {"msg": msg} if {
+    not input.review.object.metadata.labels["app"]
+    msg := "missing required label: app"
+}
+`
+		compiler := compileModule(t, "test", module)
+		e := &evaler{c: compiler}
+
+		pack := &policyPack{
+			Name: "test",
+			Policies: []*policyRule{
+				{Name: "violation", Level: mandatoryRule, Scope: resourceScope},
+			},
+		}
+
+		input := map[string]any{
+			"review": map[string]any{
+				"object": map[string]any{
+					"metadata": map[string]any{
+						"labels": map[string]any{},
+					},
+				},
+			},
+		}
+
+		results, err := e.evalPolicyPack(context.Background(), pack, input, resourceScope, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if len(results) != 1 {
+			t.Fatalf("expected 1 result, got %d", len(results))
+		}
+		if results[0].msg != "missing required label: app" {
+			t.Errorf("expected violation message, got %q", results[0].msg)
+		}
+	})
+
+	t.Run("MapWithoutMsg", func(t *testing.T) {
+		t.Parallel()
+		// A map without "msg" should fall back to fmt.Sprintf.
+		msg := extractViolationMessage(map[string]any{"details": "something"})
+		if msg == "" {
+			t.Error("expected non-empty message for map without msg key")
+		}
+	})
+
+	t.Run("StringValue", func(t *testing.T) {
+		t.Parallel()
+		msg := extractViolationMessage("plain string")
+		if msg != "plain string" {
+			t.Errorf("expected 'plain string', got %q", msg)
+		}
+	})
+}
+
+func TestEval_InputParameters(t *testing.T) {
+	t.Parallel()
+
+	// Gatekeeper-style rule accessing input.parameters.
+	module := `
+package test
+
+import rego.v1
+
+violation contains {"msg": msg} if {
+    max := input.parameters.maxReplicas
+    input.review.object.spec.replicas > max
+    msg := sprintf("replicas %d exceeds max %d", [input.review.object.spec.replicas, max])
+}
+`
+	dir := writeRegoFile(t, "policy.rego", module)
+	pack, e, err := loadPolicyPack(dir)
+	if err != nil {
+		t.Fatalf("loadPolicyPack failed: %v", err)
+	}
+	pack.InputFormat = InputFormatKubernetesAdmission
+
+	config := map[string]plugin.AnalyzerPolicyConfig{
+		"violation": {
+			Properties: map[string]any{
+				"maxReplicas": float64(3),
+			},
+		},
+	}
+
+	// Input with replicas=5 should violate.
+	input := map[string]any{
+		"review": map[string]any{
+			"object": map[string]any{
+				"spec": map[string]any{
+					"replicas": float64(5),
+				},
+			},
+		},
+	}
+
+	results, err := e.evalPolicyPack(context.Background(), pack, input, resourceScope, config)
+	if err != nil {
+		t.Fatalf("evalPolicyPack failed: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 violation, got %d", len(results))
+	}
+	if results[0].msg != "replicas 5 exceeds max 3" {
+		t.Errorf("unexpected message: %s", results[0].msg)
+	}
+
+	// Input with replicas=2 should pass.
+	input["review"].(map[string]any)["object"].(map[string]any)["spec"].(map[string]any)["replicas"] = float64(2)
+	results, err = e.evalPolicyPack(context.Background(), pack, input, resourceScope, config)
+	if err != nil {
+		t.Fatalf("evalPolicyPack failed: %v", err)
+	}
+	if len(results) != 0 {
+		t.Errorf("expected 0 violations, got %d", len(results))
+	}
 }

--- a/cmd/pulumi-analyzer-policy-opa/helpers_test.go
+++ b/cmd/pulumi-analyzer-policy-opa/helpers_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025, Pulumi Corporation.
+// Copyright 2026, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/pulumi-analyzer-policy-opa/main.go
+++ b/cmd/pulumi-analyzer-policy-opa/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025, Pulumi Corporation.
+// Copyright 2026, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/pulumi-analyzer-policy-opa/policy.go
+++ b/cmd/pulumi-analyzer-policy-opa/policy.go
@@ -1,4 +1,4 @@
-// Copyright 2025, Pulumi Corporation.
+// Copyright 2026, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/pulumi-analyzer-policy-opa/policy.go
+++ b/cmd/pulumi-analyzer-policy-opa/policy.go
@@ -25,7 +25,19 @@ import (
 	"github.com/open-policy-agent/opa/v1/ast"
 	"github.com/pkg/errors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+	"gopkg.in/yaml.v3"
 )
+
+// InputFormatKubernetesAdmission is the inputFormat value that enables
+// Gatekeeper-compatible AdmissionReview wrapping for Kubernetes resources.
+const InputFormatKubernetesAdmission = "kubernetes-admission"
+
+// policyPackManifest represents the contents of PulumiPolicy.yaml.
+type policyPackManifest struct {
+	Description string `yaml:"description"`
+	Runtime     string `yaml:"runtime"`
+	InputFormat string `yaml:"inputFormat"`
+}
 
 // Rego modules contain rules, some of which have prefixes. Only those with the appropriate
 // prefix will be considered rules for evaluation -- all others are used as library routines.
@@ -40,9 +52,21 @@ var (
 
 // loadPolicyPack loads the metadata about a pack and its policies from a directory containing OPA *.rego files.
 func loadPolicyPack(dir string) (*policyPack, *evaler, error) {
-	// First open the manifest file to learn more about the pack.
-	// TODO: we need to do this in order to provide metadata about the package itself, like its name,
-	// description, and so on. The idea here is to just put a PulumiPolicy.yaml inside the rules/ directory.
+	// Read the optional PulumiPolicy.yaml manifest for pack metadata.
+	var manifest policyPackManifest
+	manifestPath := filepath.Join(dir, "PulumiPolicy.yaml")
+	if data, err := os.ReadFile(manifestPath); err == nil {
+		if err := yaml.Unmarshal(data, &manifest); err != nil {
+			return nil, nil, errors.Wrapf(err, "parsing %s", manifestPath)
+		}
+		if manifest.InputFormat != "" && manifest.InputFormat != InputFormatKubernetesAdmission {
+			return nil, nil, errors.Errorf(
+				"unsupported inputFormat %q in %s (valid values: %q)",
+				manifest.InputFormat, manifestPath, InputFormatKubernetesAdmission)
+		}
+	} else if !os.IsNotExist(err) {
+		return nil, nil, errors.Wrapf(err, "reading %s", manifestPath)
+	}
 
 	// Next gather up all the OPA rego files to run and prepare to compile them.
 	modules := make(map[string]string)
@@ -190,6 +214,8 @@ func loadPolicyPack(dir string) (*policyPack, *evaler, error) {
 	pack := &policyPack{
 		Name:        packName,
 		DisplayName: packDisplayName,
+		Description: manifest.Description,
+		InputFormat: manifest.InputFormat,
 		Policies:    policies,
 	}
 
@@ -203,6 +229,8 @@ func loadPolicyPack(dir string) (*policyPack, *evaler, error) {
 type policyPack struct {
 	Name        string        `json:"name"`
 	DisplayName string        `json:"displayName"`
+	Description string        `json:"description"`
+	InputFormat string        `json:"inputFormat,omitempty"`
 	Policies    []*policyRule `json:"policies"`
 }
 

--- a/cmd/pulumi-analyzer-policy-opa/policy_test.go
+++ b/cmd/pulumi-analyzer-policy-opa/policy_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025, Pulumi Corporation.
+// Copyright 2026, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/pulumi-analyzer-policy-opa/policy_test.go
+++ b/cmd/pulumi-analyzer-policy-opa/policy_test.go
@@ -485,6 +485,136 @@ deny[msg] {
 	}
 }
 
+// TestLoadPolicyPack_ReadsPulumiPolicyYaml verifies that loadPolicyPack reads
+// PulumiPolicy.yaml and populates InputFormat and Description on the pack.
+func TestLoadPolicyPack_ReadsPulumiPolicyYaml(t *testing.T) {
+	t.Parallel()
+
+	t.Run("KubernetesAdmission", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		manifest := `description: K8s Gatekeeper Policies
+runtime: opa
+inputFormat: kubernetes-admission
+`
+		if err := os.WriteFile(filepath.Join(dir, "PulumiPolicy.yaml"), []byte(manifest), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "policy.rego"), []byte(`
+package test
+violation[msg] { msg := "fail" }
+`), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		pack, _, err := loadPolicyPack(dir)
+		if err != nil {
+			t.Fatalf("loadPolicyPack failed: %v", err)
+		}
+		if pack.InputFormat != "kubernetes-admission" {
+			t.Errorf("expected InputFormat = kubernetes-admission, got %q", pack.InputFormat)
+		}
+		if pack.Description != "K8s Gatekeeper Policies" {
+			t.Errorf("expected Description from manifest, got %q", pack.Description)
+		}
+	})
+
+	t.Run("EmptyInputFormat", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		manifest := `description: Standard Policy Pack
+runtime: opa
+`
+		if err := os.WriteFile(filepath.Join(dir, "PulumiPolicy.yaml"), []byte(manifest), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "policy.rego"), []byte(`
+package test
+deny[msg] { msg := "fail" }
+`), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		pack, _, err := loadPolicyPack(dir)
+		if err != nil {
+			t.Fatalf("loadPolicyPack failed: %v", err)
+		}
+		if pack.InputFormat != "" {
+			t.Errorf("expected empty InputFormat, got %q", pack.InputFormat)
+		}
+		if pack.Description != "Standard Policy Pack" {
+			t.Errorf("expected Description from manifest, got %q", pack.Description)
+		}
+	})
+
+	t.Run("NoManifest", func(t *testing.T) {
+		t.Parallel()
+		dir := writeRegoFile(t, "policy.rego", `
+package test
+deny[msg] { msg := "fail" }
+`)
+		pack, _, err := loadPolicyPack(dir)
+		if err != nil {
+			t.Fatalf("loadPolicyPack failed: %v", err)
+		}
+		if pack.InputFormat != "" {
+			t.Errorf("expected empty InputFormat when no manifest, got %q", pack.InputFormat)
+		}
+		if pack.Description != "" {
+			t.Errorf("expected empty Description when no manifest, got %q", pack.Description)
+		}
+	})
+}
+
+// TestLoadPolicyPack_InvalidInputFormat verifies that loadPolicyPack returns an
+// error for unsupported inputFormat values.
+func TestLoadPolicyPack_InvalidInputFormat(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	manifest := `description: Bad Pack
+runtime: opa
+inputFormat: unsupported-format
+`
+	if err := os.WriteFile(filepath.Join(dir, "PulumiPolicy.yaml"), []byte(manifest), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "policy.rego"), []byte(`
+package test
+deny[msg] { msg := "fail" }
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, _, err := loadPolicyPack(dir)
+	if err == nil {
+		t.Fatal("expected error for unsupported inputFormat")
+	}
+	if !strings.Contains(err.Error(), "unsupported inputFormat") {
+		t.Errorf("expected 'unsupported inputFormat' in error, got: %v", err)
+	}
+}
+
+// TestLoadPolicyPack_MalformedManifest verifies that loadPolicyPack returns an
+// error when PulumiPolicy.yaml contains invalid YAML.
+func TestLoadPolicyPack_MalformedManifest(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "PulumiPolicy.yaml"), []byte(":::invalid yaml"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "policy.rego"), []byte(`
+package test
+deny[msg] { msg := "fail" }
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, _, err := loadPolicyPack(dir)
+	if err == nil {
+		t.Fatal("expected error for malformed YAML")
+	}
+}
+
 // TestLoadPolicies_InvalidRego verifies that loadPolicyPack returns an error
 // when Rego files contain syntax errors.
 func TestLoadPolicies_InvalidRego(t *testing.T) {

--- a/cmd/pulumi-analyzer-policy-opa/serve.go
+++ b/cmd/pulumi-analyzer-policy-opa/serve.go
@@ -1,4 +1,4 @@
-// Copyright 2025, Pulumi Corporation.
+// Copyright 2026, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/examples/app/index.ts
+++ b/examples/app/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2025, Pulumi Corporation.
+// Copyright 2026, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/examples/policy-kubernetes-gatekeeper/PulumiPolicy.yaml
+++ b/examples/policy-kubernetes-gatekeeper/PulumiPolicy.yaml
@@ -1,0 +1,3 @@
+description: Kubernetes Gatekeeper Policy Pack — reuses OPA Gatekeeper constraint templates.
+runtime: opa
+inputFormat: kubernetes-admission

--- a/examples/policy-kubernetes-gatekeeper/gatekeeper.rego
+++ b/examples/policy-kubernetes-gatekeeper/gatekeeper.rego
@@ -1,0 +1,34 @@
+# METADATA
+# title: Kubernetes Gatekeeper Policies
+# scope: package
+package gatekeeper
+
+import rego.v1
+
+# This file demonstrates reusing OPA Gatekeeper constraint template rules
+# with Pulumi. When `inputFormat: kubernetes-admission` is set in PulumiPolicy.yaml,
+# Pulumi wraps Kubernetes resources in the Gatekeeper AdmissionReview structure
+# so these rules work without modification.
+
+# METADATA
+# title: Require App Label
+# description: All Kubernetes resources must have an "app" label.
+# custom:
+#   message: Add an "app" label to the resource metadata.
+violation contains {"msg": msg} if {
+    not input.review.object.metadata.labels["app"]
+    msg := sprintf("%s '%s' is missing required label: app",
+        [input.review.kind.kind, input.review.name])
+}
+
+# METADATA
+# title: Disallow Latest Tag
+# description: Container images must not use the "latest" tag.
+# custom:
+#   message: Pin the container image to a specific version tag.
+deny contains msg if {
+    container := input.review.object.spec.template.spec.containers[_]
+    endswith(container.image, ":latest")
+    msg := sprintf("container '%s' uses the 'latest' tag — pin to a specific version",
+        [container.name])
+}

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/pulumi/pulumi/sdk/v3 v3.206.0
 	google.golang.org/grpc v1.75.1
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -126,7 +127,6 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20251103181224-f26f9409b101 // indirect
 	google.golang.org/protobuf v1.36.10 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	lukechampine.com/frand v1.4.2 // indirect
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )

--- a/tests/integration/aws/s3-insecure/index.ts
+++ b/tests/integration/aws/s3-insecure/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2025, Pulumi Corporation.
+// Copyright 2026, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/integration/aws/s3-secure/index.ts
+++ b/tests/integration/aws/s3-secure/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2025, Pulumi Corporation.
+// Copyright 2026, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/integration/kubernetes/insecure-deployment/index.ts
+++ b/tests/integration/kubernetes/insecure-deployment/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2025, Pulumi Corporation.
+// Copyright 2026, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/integration/kubernetes/secure-deployment/index.ts
+++ b/tests/integration/kubernetes/secure-deployment/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2025, Pulumi Corporation.
+// Copyright 2026, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/kubernetes-admission/PulumiPolicy.yaml
+++ b/tests/kubernetes-admission/PulumiPolicy.yaml
@@ -1,0 +1,3 @@
+description: Kubernetes Gatekeeper-style Policy Pack (for testing)
+runtime: opa
+inputFormat: kubernetes-admission

--- a/tests/kubernetes-admission/fixtures/deployment_invalid_no_labels.json
+++ b/tests/kubernetes-admission/fixtures/deployment_invalid_no_labels.json
@@ -1,0 +1,26 @@
+{
+  "review": {
+    "object": {
+      "apiVersion": "apps/v1",
+      "kind": "Deployment",
+      "metadata": {
+        "name": "bad-deployment",
+        "labels": {}
+      },
+      "spec": {
+        "replicas": 2
+      }
+    },
+    "kind": {
+      "group": "apps",
+      "version": "v1",
+      "kind": "Deployment"
+    },
+    "name": "bad-deployment",
+    "namespace": "default",
+    "operation": "CREATE"
+  },
+  "parameters": {
+    "maxReplicas": 5
+  }
+}

--- a/tests/kubernetes-admission/fixtures/deployment_valid.json
+++ b/tests/kubernetes-admission/fixtures/deployment_valid.json
@@ -1,0 +1,28 @@
+{
+  "review": {
+    "object": {
+      "apiVersion": "apps/v1",
+      "kind": "Deployment",
+      "metadata": {
+        "name": "nginx-deployment",
+        "labels": {
+          "app": "nginx"
+        }
+      },
+      "spec": {
+        "replicas": 2
+      }
+    },
+    "kind": {
+      "group": "apps",
+      "version": "v1",
+      "kind": "Deployment"
+    },
+    "name": "nginx-deployment",
+    "namespace": "default",
+    "operation": "CREATE"
+  },
+  "parameters": {
+    "maxReplicas": 5
+  }
+}

--- a/tests/kubernetes-admission/policies/replica_limits.rego
+++ b/tests/kubernetes-admission/policies/replica_limits.rego
@@ -1,0 +1,10 @@
+# Gatekeeper-style policy enforcing maximum replicas via input.parameters.
+package kubernetes_admission
+
+import rego.v1
+
+violation contains {"msg": msg} if {
+    input.review.object.spec.replicas > input.parameters.maxReplicas
+    msg := sprintf("Deployment '%s' has %d replicas, max allowed is %d",
+        [input.review.name, input.review.object.spec.replicas, input.parameters.maxReplicas])
+}

--- a/tests/kubernetes-admission/policies/require_labels.rego
+++ b/tests/kubernetes-admission/policies/require_labels.rego
@@ -1,0 +1,10 @@
+# Gatekeeper-style policy requiring the "app" label on all resources.
+# This uses the standard input.review.object structure from OPA Gatekeeper.
+package kubernetes_admission
+
+import rego.v1
+
+violation contains {"msg": msg} if {
+    not input.review.object.metadata.labels["app"]
+    msg := sprintf("%s '%s' is missing required label: app", [input.review.kind.kind, input.review.name])
+}

--- a/tests/test_runner_test.go
+++ b/tests/test_runner_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025, Pulumi Corporation.
+// Copyright 2026, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Summary

- Add `inputFormat: kubernetes-admission` to `PulumiPolicy.yaml` so users can drop existing OPA Gatekeeper `.rego` files into a Pulumi policy pack and have them work without modification
- When active, Kubernetes resources are wrapped in the Gatekeeper AdmissionReview structure (`input.review.object`, `input.review.kind`, etc.) before OPA evaluation
- Non-Kubernetes resources are silently skipped (Gatekeeper rules are meaningless for non-K8s resources)
- Gatekeeper `violation[{"msg": ...}]` map return format is handled alongside existing string-based rules
- Per-rule policy config is injected as `input.parameters` for Gatekeeper Constraint compatibility
- `input._pulumi` escape hatch provides access to Pulumi-specific metadata (URN, options, provider)
- Works for both resource-level (`Analyze`) and stack-level (`AnalyzeStack`) evaluation

Closes #5

## Test plan

- [x] `TestParseK8sTypeToken` — table-driven: apps/v1:Deployment, core/v1:Pod, networking.k8s.io/v1:NetworkPolicy, non-K8s types, malformed tokens (9 cases)
- [x] `TestBuildKubernetesAdmissionInput` — review.object, review.kind, name/namespace extraction, apiVersion synthesis, core group handling, existing apiVersion preserved (4 cases)
- [x] `TestBuildKubernetesAdmissionStackInput` — filters non-K8s, empty when all non-K8s (2 cases)
- [x] `TestExtractViolationMessage` — string, map with msg, map without msg, map with non-string msg, integer, bool (6 cases)
- [x] `TestCloneInputWithParameters` — map input (no mutation of original), non-map passthrough, nil input (3 cases)
- [x] `TestEval_GatekeeperViolationMap` — end-to-end `violation[{"msg": ...}]` through eval pipeline
- [x] `TestEval_InputParameters` — injected, not injected when non-admission format, not injected when rule not in config, not injected when properties empty, nil policyConfig (5 cases)
- [x] `TestLoadPolicyPack_ReadsPulumiPolicyYaml` — kubernetes-admission, empty inputFormat, no manifest (3 cases)
- [x] `TestLoadPolicyPack_InvalidInputFormat` — error on unknown values
- [x] `TestLoadPolicyPack_MalformedManifest` — error on invalid YAML
- [x] `TestKubernetesAdmission_Integration` — full Analyze() path: label violation fires, valid resource passes, non-K8s skipped (3 cases)
- [x] `TestKubernetesAdmission_AnalyzeStack` — full AnalyzeStack() path: stack rule fires for bad resource, non-K8s filtered out
- [x] All existing tests pass (`go test ./...`)


🤖 Generated with [Claude Code](https://claude.com/claude-code)