### PR TITLE
Remove manual plugin install step from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,14 +61,10 @@ pulumi preview --policy-pack ./policies
 
 ### Prerequisites
 
-- **Pulumi CLI** (v3.0+): [Install Pulumi](https://www.pulumi.com/docs/get-started/install/)
+- **Pulumi CLI** (v3.227.0+): [Install Pulumi](https://www.pulumi.com/docs/get-started/install/)
 - **OPA CLI** (optional, for testing): [Install OPA](https://www.openpolicyagent.org/docs/latest/#1-download-opa)
 
-Install the analyzer:
-
-```bash
-pulumi plugin install analyzer policy-opa
-```
+The OPA analyzer plugin is installed automatically when you first run a policy pack with `runtime: opa`.
 
 ---
 


### PR DESCRIPTION
## Summary
- Pulumi v3.227.0+ installs the OPA analyzer plugin automatically on first use, so the manual `pulumi plugin install analyzer policy-opa` step is no longer needed
- Bumped minimum Pulumi CLI version to v3.227.0 in prerequisites

## Test plan
- [ ] Verify README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)