### PR TITLE
Make OPA policy authoring failures loud and self-correcting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Improvements
 
 - **Unrecognized rule names now warn**: OPA rules with names that lack a recognized prefix
-  (`deny`, `violation`, `warn`, `stack_deny`, `stack_warn`) now emit a clear stderr warning
+  (`deny`, `violation`, `warn`, `stack_deny`, `stack_violation`, `stack_warn`) now emit a clear stderr warning
   explaining the rule won't be evaluated and how to rename it. Previously these were silently
   skipped. (#42)
 - **Empty policy packs now warn loudly**: a pack that would evaluate no rules at all — every

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@
   (`deny`, `violation`, `warn`, `stack_deny`, `stack_warn`) now emit a clear stderr warning
   explaining the rule won't be evaluated and how to rename it. Previously these were silently
   skipped. (#42)
+- **Empty policy packs now warn loudly**: a pack that would evaluate no rules at all — every
+  rule is an unrecognized helper, or the pack is empty — now emits a prominent
+  `warning[opa/zero-rules]` banner, since such a pack silently enforces nothing. It remains a
+  warning (not an error) so incremental authoring isn't blocked. (#42)
+- **Stable diagnostic codes**: authoring-time warnings are now tagged with stable
+  `warning[opa/<code>]` identifiers (`opa/unrecognized-rule`, `opa/zero-rules`,
+  `opa/duplicate-rule`, `opa/missing-config`) and an explicit `Fix:` clause, so CI and agent
+  tooling can recognize and gate on a diagnostic class without parsing prose. (#42)
 - **`input.props` and `input.__props` aliases**: Resource properties are now also available
   under `input.props` and `input.__props`, aliasing the existing `input.properties` and
   `input.__properties`, to match the Node policy SDK convention. (#42)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## Unreleased
+
+### Improvements
+
+- **Unrecognized rule names now warn**: OPA rules with names that lack a recognized prefix
+  (`deny`, `violation`, `warn`, `stack_deny`, `stack_warn`) now emit a clear stderr warning
+  explaining the rule won't be evaluated and how to rename it. Previously these were silently
+  skipped. (#42)
+- **`input.props` and `input.__props` aliases**: Resource properties are now also available
+  under `input.props` and `input.__props`, aliasing the existing `input.properties` and
+  `input.__properties`, to match the Node policy SDK convention. (#42)
+
 ## v1.1.0
 
 ### New Features

--- a/README.md
+++ b/README.md
@@ -811,9 +811,19 @@ Rules can include a suffix for disambiguation (e.g. `deny_public_buckets`, `stac
 > **Common silent failure:** a misnamed rule simply doesn't run — no error, no violation.
 > `denyPublicBuckets` (camelCase), `denies_public` (typo), and `Deny_Public` (wrong case)
 > are all treated as helpers and skipped. When the analyzer detects a name that *looks* like
-> a mistyped rule, it prints a `warning:` to stderr naming the rule and how to fix it, but the
-> safest habit is to copy a working prefix exactly: `deny`, `deny_<name>`, `violation`,
-> `violation_<name>`, `warn`, `warn_<name>`, or the `stack_`-prefixed forms.
+> a mistyped rule it prints `warning[opa/unrecognized-rule]` to stderr naming the rule and how
+> to fix it; if **no** rule in the pack is recognized it prints `warning[opa/zero-rules]` (the
+> pack would enforce nothing). These `warning[opa/...]` codes are stable — grep for them in CI
+> to fail a build on misnamed policies. The safest habit is to copy a working prefix exactly.
+
+**Name rules exactly like the left column — anything else is silently skipped:**
+
+| ✅ Evaluated | ❌ Skipped (treated as a helper) | Why it's skipped |
+|---|---|---|
+| `deny_public_buckets[msg]` | `denyPublicBuckets[msg]` | camelCase instead of `snake_case` |
+| `violation_open_ports[msg]` | `Deny_Public[msg]` | wrong case (`Deny`, not `deny`) |
+| `warn_missing_tags[msg]` | `denies_public[msg]` | not a recognized keyword |
+| `stack_deny_too_many[msg]` | `require_https[msg]`, `must_have_tags[msg]` | correctly spelled, **wrong API** — use `deny`/`warn`, not synonyms like `require`/`must`/`ensure` |
 
 ```rego
 # METADATA
@@ -924,7 +934,7 @@ of the idioms above. See [Testing Your Policies](#testing-your-policies).
 
 ### Violations not shown
 
-1. Rule must use a recognized prefix: `deny`, `violation`, `warn`, `stack_deny`, `stack_violation`, or `stack_warn`. Prefixes are **case-sensitive** and use **underscores** (`deny_public`, not `denyPublic` or `Deny_Public`). A misnamed rule is silently treated as a helper and never runs — watch stderr for a `warning: rule ... will NOT be evaluated` message.
+1. Rule must use a recognized prefix: `deny`, `violation`, `warn`, `stack_deny`, `stack_violation`, or `stack_warn`. Prefixes are **case-sensitive** and use **underscores** (`deny_public`, not `denyPublic` or `Deny_Public`). A misnamed rule is silently treated as a helper and never runs — watch stderr for `warning[opa/unrecognized-rule]` (a single misnamed rule) or `warning[opa/zero-rules]` (the whole pack evaluates nothing). See [Rule Prefixes and Severity](#rule-prefixes-and-severity) for the ✅/❌ naming table.
 2. Check your Rego idioms — `not input.tags` does **not** mean "tags is empty"; use `count(input.tags) == 0`. See [Best Practices → Know the Rego Idioms That Bite](#5-know-the-rego-idioms-that-bite).
 3. Verify the input structure matches your resource type (properties are at the top level or under `input.properties`, never under `input.args`).
 4. Use `pulumi preview --policy-pack ./policies --debug` for verbose output

--- a/README.md
+++ b/README.md
@@ -300,6 +300,13 @@ input.acl              # e.g. "public-read"
 input.bucketName       # e.g. "my-bucket"
 ```
 
+> **There is no `args.props` here.** Properties live at the **top level** of `input`
+> (`input.acl`) and in the **`input.properties`** bag (`input.properties.acl`). The Node.js
+> Policy SDK exposes resource inputs as `args.props`, which trips up authors porting rules:
+> in OPA there is no `args` object. For convenience `input.props` is accepted as an alias for
+> `input.properties`, but prefer `input.<property>` or `input.properties.<property>` — a typo'd
+> path like `input.args.props.acl` is simply `undefined` and silently makes the rule never fire.
+
 ### Metadata Fields
 
 The following metadata fields are also available at the top level. If a resource property has the same key as a metadata field, the property takes precedence. Use the `__`-prefixed versions for guaranteed access:
@@ -312,6 +319,7 @@ The following metadata fields are also available at the top level. If a resource
 | `input.options` | `input.__options` | Resource options (see below) |
 | `input.provider` | `input.__provider` | Provider information (see below) |
 | `input.properties` | `input.__properties` | Nested properties bag |
+| `input.props` | `input.__props` | Alias for `input.properties` (see callout above) |
 
 ### Resource Options
 
@@ -783,7 +791,12 @@ All `.rego` files in a policy pack **must** use the same package name. Subpackag
 
 ### Rule Prefixes and Severity
 
-Rules are identified by their name prefix, which determines the enforcement level and scope:
+**The rule name prefix is the API.** A rule is only evaluated if its name matches one of
+the recognized prefixes below. Any rule whose name doesn't match is treated as a helper
+("library routine") and is **never evaluated** — it will not fire, pass, or fail. There is
+no separate annotation or registration step: the prefix alone decides whether a rule runs.
+
+The prefixes are **case-sensitive** and use **underscores** as separators:
 
 **Resource-level rules** (evaluated per-resource via `Analyze`):
 - **`deny[msg]`** or **`violation[msg]`** - Mandatory (blocks deployment)
@@ -794,6 +807,13 @@ Rules are identified by their name prefix, which determines the enforcement leve
 - **`stack_warn[msg]`** - Advisory (shows warning only)
 
 Rules can include a suffix for disambiguation (e.g. `deny_public_buckets`, `stack_warn_orphan_sgs`).
+
+> **Common silent failure:** a misnamed rule simply doesn't run — no error, no violation.
+> `denyPublicBuckets` (camelCase), `denies_public` (typo), and `Deny_Public` (wrong case)
+> are all treated as helpers and skipped. When the analyzer detects a name that *looks* like
+> a mistyped rule, it prints a `warning:` to stderr naming the rule and how to fix it, but the
+> safest habit is to copy a working prefix exactly: `deny`, `deny_<name>`, `violation`,
+> `violation_<name>`, `warn`, `warn_<name>`, or the `stack_`-prefixed forms.
 
 ```rego
 # METADATA
@@ -876,6 +896,22 @@ deny_workload_security[msg] {
 
 Always create fixtures for both valid (should pass) and invalid (should fail) configurations.
 
+### 5. Know the Rego Idioms That Bite
+
+A handful of Rego idioms look correct but silently make a rule fire on 0% or 100% of
+resources. These are the most common ways a policy "passes" without ever doing anything:
+
+| Goal | ✅ Do this | ❌ Not this | Why the wrong form fails silently |
+|------|-----------|------------|-----------------------------------|
+| "collection is empty / missing" | `count(input.tags) == 0` | `not input.tags` | `not input.tags` is only true when the key is **absent**. An empty list/object (`[]`, `{}`) is still "defined", so the rule fires on 0% of real resources. |
+| "key exists" | `input.encryption` | `input.encryption == true` | A non-boolean (e.g. a config block) is truthy in `input.encryption` but `!= true`, so the equality form fires on 0%. |
+| "no element matches" | `count([x | x := input.rules[_]; bad(x)]) == 0` | `not input.rules[_]` | `not input.rules[_]` negates over the whole collection and rarely means what you expect. |
+| read a property | `input.acl` or `input.properties.acl` | `input.args.props.acl` | There is no `args` object (that's the Node SDK). The path is `undefined`, so the rule never fires. |
+
+When in doubt, run `opa eval` against a fixture you *know* should violate and confirm you
+get a result — a rule that returns nothing on a known-bad input is the tell-tale sign of one
+of the idioms above. See [Testing Your Policies](#testing-your-policies).
+
 ---
 
 ## Troubleshooting
@@ -888,9 +924,10 @@ Always create fixtures for both valid (should pass) and invalid (should fail) co
 
 ### Violations not shown
 
-1. Rule must use a recognized prefix: `deny`, `violation`, `warn`, `stack_deny`, `stack_violation`, or `stack_warn`
-2. Verify the input structure matches your resource type
-3. Use `pulumi preview --policy-pack ./policies --debug` for verbose output
+1. Rule must use a recognized prefix: `deny`, `violation`, `warn`, `stack_deny`, `stack_violation`, or `stack_warn`. Prefixes are **case-sensitive** and use **underscores** (`deny_public`, not `denyPublic` or `Deny_Public`). A misnamed rule is silently treated as a helper and never runs — watch stderr for a `warning: rule ... will NOT be evaluated` message.
+2. Check your Rego idioms — `not input.tags` does **not** mean "tags is empty"; use `count(input.tags) == 0`. See [Best Practices → Know the Rego Idioms That Bite](#5-know-the-rego-idioms-that-bite).
+3. Verify the input structure matches your resource type (properties are at the top level or under `input.properties`, never under `input.args`).
+4. Use `pulumi preview --policy-pack ./policies --debug` for verbose output
 
 ### Gatekeeper rules not firing
 

--- a/README.md
+++ b/README.md
@@ -846,7 +846,7 @@ deny_public_access[msg] {
 # custom:
 #   message: Add a loggings configuration block.
 warn_logging[msg] {
-    not input.loggings
+    count(object.get(input, "loggings", [])) == 0
     msg := "Consider enabling access logs"
 }
 
@@ -952,11 +952,12 @@ of the idioms above. See [Testing Your Policies](#testing-your-policies).
 
 ### Policy passes but shouldn't
 
-Add a temporary debug rule to inspect the input:
+Add a temporary advisory rule to inspect the input — the `warn_` prefix makes it actually
+evaluate, and `__type`/`__name` are collision-safe:
 
 ```rego
-debug_input[msg] {
-    msg := sprintf("Type: %s, Name: %s", [input.type, input.__name])
+warn_debug_input[msg] {
+    msg := sprintf("Type: %s, Name: %s", [input.__type, input.__name])
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -304,7 +304,9 @@ input.bucketName       # e.g. "my-bucket"
 > (`input.acl`) and in the **`input.properties`** bag (`input.properties.acl`). The Node.js
 > Policy SDK exposes resource inputs as `args.props`, which trips up authors porting rules:
 > in OPA there is no `args` object. For convenience `input.props` is accepted as an alias for
-> `input.properties`, but prefer `input.<property>` or `input.properties.<property>` — a typo'd
+> `input.properties`, but prefer `input.<property>` or `input.properties.<property>`. Like any
+> top-level field, `input.props`/`input.properties` can be shadowed by a resource property of the
+> same name — `input.__props`/`input.__properties` are always collision-safe. A typo'd
 > path like `input.args.props.acl` is simply `undefined`, and an undefined reference fails
 > silently in either direction: the rule matches **nothing**, or **everything** if the reference
 > sits under `not` (e.g. `not input.args.props.acl` is always true).

--- a/README.md
+++ b/README.md
@@ -305,7 +305,9 @@ input.bucketName       # e.g. "my-bucket"
 > Policy SDK exposes resource inputs as `args.props`, which trips up authors porting rules:
 > in OPA there is no `args` object. For convenience `input.props` is accepted as an alias for
 > `input.properties`, but prefer `input.<property>` or `input.properties.<property>` — a typo'd
-> path like `input.args.props.acl` is simply `undefined` and silently makes the rule never fire.
+> path like `input.args.props.acl` is simply `undefined`, and an undefined reference fails
+> silently in either direction: the rule matches **nothing**, or **everything** if the reference
+> sits under `not` (e.g. `not input.args.props.acl` is always true).
 
 ### Metadata Fields
 
@@ -501,7 +503,7 @@ Stack-level policies evaluate the entire set of resources in a stack, enabling c
 
 ### Writing Stack-Level Rules
 
-Use the `stack_deny` or `stack_warn` prefix. The input contains a `resources` array with all resources in the stack:
+Use the `stack_deny`, `stack_violation`, or `stack_warn` prefix. The input contains a `resources` array with all resources in the stack:
 
 ```rego
 package mypack
@@ -913,10 +915,10 @@ resources. These are the most common ways a policy "passes" without ever doing a
 
 | Goal | ✅ Do this | ❌ Not this | Why the wrong form fails silently |
 |------|-----------|------------|-----------------------------------|
-| "collection is empty / missing" | `count(input.tags) == 0` | `not input.tags` | `not input.tags` is only true when the key is **absent**. An empty list/object (`[]`, `{}`) is still "defined", so the rule fires on 0% of real resources. |
+| "collection is empty or missing" | `count(object.get(input, "tags", [])) == 0` | `not input.tags` or `count(input.tags) == 0` | `not input.tags` matches only a **missing** key (an empty `[]`/`{}` is still "defined"); `count(input.tags) == 0` matches only a **present-but-empty** value — it's `undefined` (so never matches) when the key is missing. `object.get(..., [])` supplies a default, covering both. |
 | "key exists" | `input.encryption` | `input.encryption == true` | A non-boolean (e.g. a config block) is truthy in `input.encryption` but `!= true`, so the equality form fires on 0%. |
 | "no element matches" | `count([x | x := input.rules[_]; bad(x)]) == 0` | `not input.rules[_]` | `not input.rules[_]` negates over the whole collection and rarely means what you expect. |
-| read a property | `input.acl` or `input.properties.acl` | `input.args.props.acl` | There is no `args` object (that's the Node SDK). The path is `undefined`, so the rule never fires. |
+| read a property | `input.acl` or `input.properties.acl` | `input.args.props.acl` | There is no `args` object (that's the Node SDK). The path is `undefined`, so the rule fires on 0% of resources — or 100% if the reference is under `not`. |
 
 When in doubt, run `opa eval` against a fixture you *know* should violate and confirm you
 get a result — a rule that returns nothing on a known-bad input is the tell-tale sign of one
@@ -935,7 +937,7 @@ of the idioms above. See [Testing Your Policies](#testing-your-policies).
 ### Violations not shown
 
 1. Rule must use a recognized prefix: `deny`, `violation`, `warn`, `stack_deny`, `stack_violation`, or `stack_warn`. Prefixes are **case-sensitive** and use **underscores** (`deny_public`, not `denyPublic` or `Deny_Public`). A misnamed rule is silently treated as a helper and never runs — watch stderr for `warning[opa/unrecognized-rule]` (a single misnamed rule) or `warning[opa/zero-rules]` (the whole pack evaluates nothing). See [Rule Prefixes and Severity](#rule-prefixes-and-severity) for the ✅/❌ naming table.
-2. Check your Rego idioms — `not input.tags` does **not** mean "tags is empty"; use `count(input.tags) == 0`. See [Best Practices → Know the Rego Idioms That Bite](#5-know-the-rego-idioms-that-bite).
+2. Check your Rego idioms — for "empty or missing", neither `not input.tags` (matches only a missing key) nor `count(input.tags) == 0` (`undefined`, so never matches, when the key is missing) is enough; use `count(object.get(input, "tags", [])) == 0`. See [Best Practices → Know the Rego Idioms That Bite](#5-know-the-rego-idioms-that-bite).
 3. Verify the input structure matches your resource type (properties are at the top level or under `input.properties`, never under `input.args`).
 4. Use `pulumi preview --policy-pack ./policies --debug` for verbose output
 

--- a/cmd/pulumi-analyzer-policy-opa/analyzer.go
+++ b/cmd/pulumi-analyzer-policy-opa/analyzer.go
@@ -293,8 +293,9 @@ func buildProviderMap(r plugin.AnalyzerResource) map[string]any {
 //
 // If a resource property has the same key as a metadata field, the resource property
 // takes precedence for backwards compatibility. Policy authors can use the __-prefixed
-// versions (__type, __urn, __name, __options, __provider, __properties) to reliably
-// access metadata regardless of property name collisions.
+// versions (__type, __urn, __name, __options, __provider, __properties/__props) to
+// reliably access metadata regardless of property name collisions. The "props" key is
+// a backwards-compatible alias for "properties".
 func buildOPAInput(r plugin.AnalyzerResource) map[string]any {
 	obj := make(map[string]any)
 
@@ -312,7 +313,12 @@ func buildOPAInput(r plugin.AnalyzerResource) map[string]any {
 
 	// Expose the properties as a nested "properties" bag so that policies
 	// can access them via input.properties.<key> without metadata key collisions.
-	obj["properties"] = r.Properties.Mappable()
+	// "props" is a backwards-compatible alias for the same bag: authors coming from
+	// the Node Policy SDK frequently reach for input.props by muscle memory, and a
+	// silent miss there produces a rule that never fires. Both point at the same map.
+	propsBag := r.Properties.Mappable()
+	obj["properties"] = propsBag
+	obj["props"] = propsBag
 
 	// Overlay resource properties so they take precedence over metadata
 	// fields at the top level for backwards compatibility.
@@ -330,6 +336,7 @@ func buildOPAInput(r plugin.AnalyzerResource) map[string]any {
 	obj["__name"] = r.Name
 	obj["__options"] = opts
 	obj["__properties"] = r.Properties.Mappable()
+	obj["__props"] = r.Properties.Mappable()
 	obj["__provider"] = providerInfo
 
 	return obj

--- a/cmd/pulumi-analyzer-policy-opa/analyzer.go
+++ b/cmd/pulumi-analyzer-policy-opa/analyzer.go
@@ -17,7 +17,7 @@ package main
 import (
 	"context"
 	"fmt"
-	"os"
+	"maps"
 	"strings"
 
 	"github.com/blang/semver"
@@ -190,8 +190,9 @@ func (a *analyzer) warnMissingConfig() {
 				continue
 			}
 		}
-		fmt.Fprintf(os.Stderr, "warning: policy %q declares a config schema but no configuration was provided; "+
-			"rules referencing data.config will not fire\n", pol.Name)
+		warnf(diagMissingConfig, "policy %q declares a config schema but no configuration was provided, so "+
+			"rules referencing data.config will not fire. Fix: provide configuration for %q in your policy "+
+			"pack config, or remove the config schema if it is unused.", pol.Name, pol.Name)
 	}
 }
 
@@ -322,9 +323,7 @@ func buildOPAInput(r plugin.AnalyzerResource) map[string]any {
 
 	// Overlay resource properties so they take precedence over metadata
 	// fields at the top level for backwards compatibility.
-	for k, v := range r.Properties.Mappable() {
-		obj[k] = v
-	}
+	maps.Copy(obj, propsBag)
 
 	// Set __-prefixed metadata fields last so they are always available as a
 	// collision-safe escape hatch, even if a resource property has the same name
@@ -411,9 +410,7 @@ func buildKubernetesAdmissionInput(
 
 	// Build the review object — start with the resource properties.
 	reviewObject := make(map[string]any, len(props)+2)
-	for k, v := range props {
-		reviewObject[k] = v
-	}
+	maps.Copy(reviewObject, props)
 
 	// Synthesize apiVersion and kind if not already present in properties.
 	if _, ok := reviewObject["apiVersion"]; !ok {

--- a/cmd/pulumi-analyzer-policy-opa/analyzer.go
+++ b/cmd/pulumi-analyzer-policy-opa/analyzer.go
@@ -316,7 +316,8 @@ func buildOPAInput(r plugin.AnalyzerResource) map[string]any {
 	// can access them via input.properties.<key> without metadata key collisions.
 	// "props" is a backwards-compatible alias for the same bag: authors coming from
 	// the Node Policy SDK frequently reach for input.props by muscle memory, and a
-	// silent miss there produces a rule that never fires. Both point at the same map.
+	// silent miss there leaves an undefined reference — a rule that matches nothing, or
+	// everything if it sits under `not`. Both point at the same map.
 	propsBag := r.Properties.Mappable()
 	obj["properties"] = propsBag
 	obj["props"] = propsBag

--- a/cmd/pulumi-analyzer-policy-opa/analyzer.go
+++ b/cmd/pulumi-analyzer-policy-opa/analyzer.go
@@ -335,8 +335,8 @@ func buildOPAInput(r plugin.AnalyzerResource) map[string]any {
 	// survives a (highly unlikely) resource property named "__name".
 	obj["__name"] = r.Name
 	obj["__options"] = opts
-	obj["__properties"] = r.Properties.Mappable()
-	obj["__props"] = r.Properties.Mappable()
+	obj["__properties"] = propsBag
+	obj["__props"] = propsBag
 	obj["__provider"] = providerInfo
 
 	return obj

--- a/cmd/pulumi-analyzer-policy-opa/analyzer.go
+++ b/cmd/pulumi-analyzer-policy-opa/analyzer.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"maps"
 	"strings"
+	"sync"
 
 	"github.com/blang/semver"
 
@@ -34,10 +35,10 @@ var VersionString = "0.0.1+dev"
 
 // analyzer implements the Analyzer interface needed to plug into Pulumi as a policy analyzer.
 type analyzer struct {
-	pack          *policyPack
-	e             *evaler
-	policyConfig  map[string]plugin.AnalyzerPolicyConfig // stored by Configure()
-	configChecked bool                                   // guards one-time missing-config warning
+	pack            *policyPack
+	e               *evaler
+	policyConfig    map[string]plugin.AnalyzerPolicyConfig // stored by Configure()
+	configCheckOnce sync.Once                              // guards the one-time missing-config warning across concurrent Analyze calls
 }
 
 func NewAnalyzer(
@@ -176,24 +177,21 @@ func (a *analyzer) Configure(policyConfig map[string]plugin.AnalyzerPolicyConfig
 // schema but was not given any configuration properties. Without config, rules that
 // reference data.config will silently not fire.
 func (a *analyzer) warnMissingConfig() {
-	if a.configChecked {
-		return
-	}
-	a.configChecked = true
-
-	for _, pol := range a.pack.Policies {
-		if pol.ConfigSchema == nil {
-			continue
-		}
-		if a.policyConfig != nil {
-			if cfg, ok := a.policyConfig[pol.Name]; ok && len(cfg.Properties) > 0 {
+	a.configCheckOnce.Do(func() {
+		for _, pol := range a.pack.Policies {
+			if pol.ConfigSchema == nil {
 				continue
 			}
+			if a.policyConfig != nil {
+				if cfg, ok := a.policyConfig[pol.Name]; ok && len(cfg.Properties) > 0 {
+					continue
+				}
+			}
+			warnf(diagMissingConfig, "policy %q declares a config schema but no configuration was provided, so "+
+				"rules referencing data.config will not fire. Fix: provide configuration for %q in your policy "+
+				"pack config, or remove the config schema if it is unused.", pol.Name, pol.Name)
 		}
-		warnf(diagMissingConfig, "policy %q declares a config schema but no configuration was provided, so "+
-			"rules referencing data.config will not fire. Fix: provide configuration for %q in your policy "+
-			"pack config, or remove the config schema if it is unused.", pol.Name, pol.Name)
-	}
+	})
 }
 
 func (a *analyzer) Cancel(ctx context.Context) error {

--- a/cmd/pulumi-analyzer-policy-opa/analyzer_integration_test.go
+++ b/cmd/pulumi-analyzer-policy-opa/analyzer_integration_test.go
@@ -634,9 +634,8 @@ deny[msg] { msg := "fail" }
 }
 
 func TestAnalyzer_GetPluginInfo(t *testing.T) {
-	t.Parallel()
-
-	// Save and restore the global VersionString.
+	// NOT parallel: this test mutates the package-global VersionString (read by
+	// buildDiagnostics), so running it concurrently would race other tests.
 	origVersion := VersionString
 	t.Cleanup(func() { VersionString = origVersion })
 

--- a/cmd/pulumi-analyzer-policy-opa/analyzer_test.go
+++ b/cmd/pulumi-analyzer-policy-opa/analyzer_test.go
@@ -342,6 +342,65 @@ func TestBuildInput(t *testing.T) {
 		}
 	})
 
+	t.Run("PropsAlias", func(t *testing.T) {
+		t.Parallel()
+		r := makeResource()
+		input := buildOPAInput(r)
+
+		// "props" is a backwards-compatible alias for "properties".
+		props, ok := input["props"].(map[string]any)
+		if !ok {
+			t.Fatal("expected input[\"props\"] to be a map")
+		}
+		if props["acl"] != "private" {
+			t.Errorf("expected props.acl = \"private\", got %v", props["acl"])
+		}
+
+		// __props is the collision-safe escape hatch, mirroring __properties.
+		dprops, ok := input["__props"].(map[string]any)
+		if !ok {
+			t.Fatal("expected input[\"__props\"] to be a map")
+		}
+		if dprops["acl"] != "private" {
+			t.Errorf("expected __props.acl = \"private\", got %v", dprops["acl"])
+		}
+
+		// props and properties should expose the same contents.
+		properties, ok := input["properties"].(map[string]any)
+		if !ok {
+			t.Fatal("expected input[\"properties\"] to be a map")
+		}
+		if props["acl"] != properties["acl"] {
+			t.Errorf("expected props and properties to match: props=%v properties=%v", props, properties)
+		}
+	})
+
+	t.Run("PropsAliasCollision", func(t *testing.T) {
+		t.Parallel()
+		r := makeResource()
+		r.Properties = resource.NewPropertyMapFromMap(map[string]any{
+			"props": "some-value",
+			"acl":   "private",
+		})
+
+		input := buildOPAInput(r)
+
+		// A resource property literally named "props" wins at the top level
+		// (consistent with how "properties" collisions are handled).
+		if input["props"] != "some-value" {
+			t.Errorf("expected resource property to take precedence at top level, got %v", input["props"])
+		}
+
+		// The collision-safe escape hatch still exposes the property bag.
+		dprops, ok := input["__props"].(map[string]any)
+		if !ok {
+			t.Fatal("expected input[\"__props\"] to be a map")
+		}
+		if dprops["acl"] != "private" {
+			t.Errorf("expected __props.acl = \"private\", got %v", dprops["acl"])
+		}
+	})
+
 	t.Run("PropertiesBagCollision", func(t *testing.T) {
 		t.Parallel()
 		r := makeResource()
@@ -614,9 +673,9 @@ func TestParseK8sTypeToken(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name    string
-		token   string
-		want    *k8sTypeInfo
+		name  string
+		token string
+		want  *k8sTypeInfo
 	}{
 		{
 			name:  "apps/v1 Deployment",

--- a/cmd/pulumi-analyzer-policy-opa/config_test.go
+++ b/cmd/pulumi-analyzer-policy-opa/config_test.go
@@ -920,7 +920,11 @@ func captureStderr(t *testing.T, fn func()) string {
 	_ = w.Close()
 	os.Stderr = origStderr
 
-	out, _ := io.ReadAll(r)
+	out, readErr := io.ReadAll(r)
+	if readErr != nil {
+		t.Fatalf("failed to read captured stderr: %v", readErr)
+	}
+	_ = r.Close()
 	return string(out)
 }
 

--- a/cmd/pulumi-analyzer-policy-opa/config_test.go
+++ b/cmd/pulumi-analyzer-policy-opa/config_test.go
@@ -970,6 +970,9 @@ deny_size[msg] {
 			})
 		})
 
+		if !strings.Contains(stderr, "warning[opa/missing-config]") {
+			t.Errorf("expected stable diagnostic code, got: %q", stderr)
+		}
 		if !strings.Contains(stderr, "deny_size") {
 			t.Errorf("expected warning mentioning deny_size, got: %q", stderr)
 		}

--- a/cmd/pulumi-analyzer-policy-opa/policy.go
+++ b/cmd/pulumi-analyzer-policy-opa/policy.go
@@ -51,15 +51,33 @@ var (
 )
 
 // ruleLikeNamePrefix matches rule names that look like they were intended to be
-// evaluated rules but use the wrong casing, a near-miss spelling, or a malformed
-// separator (e.g. "Deny", "denies", "denyPublic", "deny-public", "stack_deniy").
-// It is deliberately anchored on the recognized intent keywords plus a few common
-// LLM/human misspellings so that legitimate helper routines (e.g. "is_public",
-// "valid_cidr", "has_encryption") never trip the warning. A match here that is NOT
-// also matched by one of the exact prefix regexes above indicates a rule that will
-// be silently skipped, which warnUnrecognizedRule reports.
+// evaluated rules but use the wrong casing, a near-miss spelling, a malformed
+// separator (e.g. "Deny", "denies", "denyPublic", "deny-public", "stack_deniy"), or
+// an imperative policy verb that implies intent to enforce something
+// (e.g. "require_versioning", "must_have_tags", "ensure_https", "check_public").
+//
+// Each keyword must be a discrete leading token — it has to be followed by a word
+// boundary (underscore, separator, end-of-name, or a camelCase capital/digit), not
+// just more lowercase letters. That keeps the imperative verbs from swallowing
+// legitimate value/boolean helpers whose names merely begin with the same letters
+// (e.g. "required_labels", "checksum", "blocklist", "validated_at"), which along with
+// helpers like "is_public"/"valid_cidr"/"has_encryption" never trip the name
+// heuristic. A match here that is NOT also matched by one of the exact prefix regexes
+// above is one of two triggers (the other being the rule's set-producing shape) that
+// warnUnrecognizedRule reports.
+//
+// The keyword groups are scoped case-insensitive (?i:...), but the trailing
+// word-boundary class [A-Z0-9] is intentionally case-sensitive: a global (?i) flag
+// would make [A-Z] match any letter and defeat the boundary, re-admitting
+// "required_labels", "checksum", etc.
 var ruleLikeNamePrefix = regexp.MustCompile(
-	`(?i)^(stack[_-]?)?(deny|denies|denied|violation|violations|violate|warn|warns|warning|warnings)`)
+	`^(?i:stack[_-]?)?(?i:` +
+		`deny|denies|violation|violations|violate|warn|warns|warning|warnings|` +
+		`require|requires|must|ensure|ensures|enforce|enforces|should|` +
+		`check|checks|validate|validates|verify|verifies|disallow|disallows|` +
+		`prohibit|prohibits|forbid|forbids|restrict|restricts|block|blocks|` +
+		`prevent|prevents|mandate|mandates|reject|rejects` +
+		`)(_|-|[A-Z0-9]|$)`)
 
 // loadPolicyPack loads the metadata about a pack and its policies from a directory containing OPA *.rego files.
 func loadPolicyPack(dir string) (*policyPack, *evaler, error) {
@@ -162,11 +180,14 @@ func loadPolicyPack(dir string) (*policyPack, *evaler, error) {
 				scope = resourceScope
 			} else {
 				// This rule does not match any recognized prefix, so it will be
-				// treated as a library routine and never evaluated. If the name
-				// looks like it was *meant* to be a rule (wrong casing, a typo, or
-				// a bad separator), warn loudly so the author gets a signal instead
-				// of a rule that silently never fires.
-				warnUnrecognizedRule(ruleName, name)
+				// treated as a library routine and never evaluated. If the rule has
+				// the shape of a policy (a partial set/object rule that builds up a
+				// collection of messages — Head.Key set, no function args) or its
+				// name looks like it was *meant* to be a rule (wrong casing, a typo,
+				// or an imperative policy verb), warn loudly so the author gets a
+				// signal instead of a rule that silently never fires.
+				policyShaped := rule.Head.Key != nil && len(rule.Head.Args) == 0
+				warnUnrecognizedRule(ruleName, name, policyShaped)
 				continue // skip
 			}
 
@@ -242,24 +263,48 @@ func loadPolicyPack(dir string) (*policyPack, *evaler, error) {
 	return pack, e, nil
 }
 
-// warnUnrecognizedRule emits a one-time stderr warning for a rule whose name looks
-// like it was intended to be an evaluated rule but does not match a recognized
-// prefix, so it is silently treated as a helper and never runs. The message names
-// the rule, explains why it won't run, and shows how to fix it. It mirrors the
-// stderr style used by warnMissingConfig.
+// warnUnrecognizedRule emits a one-time stderr warning for a rule that does not match
+// a recognized prefix — so it is silently treated as a helper and never runs — but
+// looks like it was meant to be evaluated. There are two independent triggers:
 //
-// Rules that don't look rule-like at all (legitimate helpers such as "is_public")
-// are not reported.
-func warnUnrecognizedRule(ruleName, module string) {
-	if !ruleLikeNamePrefix.MatchString(ruleName) {
+//   - policyShaped: the rule is a partial set/object rule that builds up a collection
+//     of messages (the deny/warn shape), which is the most robust signal that the
+//     author intended it as a policy regardless of what they named it; or
+//   - its name matches ruleLikeNamePrefix — wrong casing, a near-miss spelling, or an
+//     imperative policy verb (require/must/ensure/check/...) that implies enforcement.
+//
+// The message names the rule, explains why it was flagged and why it won't run, shows
+// how to fix it, and notes that an intentional helper can be ignored or renamed so it
+// no longer looks rule-like. It mirrors the stderr style used by warnMissingConfig.
+//
+// Rules that are neither policy-shaped nor rule-like by name (genuine boolean/value/
+// function helpers such as "is_public", "required_labels", "valid_cidr") are not
+// reported.
+func warnUnrecognizedRule(ruleName, module string, policyShaped bool) {
+	nameLooksRuleLike := ruleLikeNamePrefix.MatchString(ruleName)
+	if !policyShaped && !nameLooksRuleLike {
 		return
 	}
+
+	var reason string
+	switch {
+	case policyShaped && nameLooksRuleLike:
+		reason = "it builds up a set of messages and its name implies intent to enforce a policy"
+	case policyShaped:
+		reason = "it builds up a set of messages like a deny/warn rule"
+	default:
+		reason = "its name implies intent to enforce a policy"
+	}
+
 	fmt.Fprintf(os.Stderr, "warning: rule %q in module %q will NOT be evaluated because its name does not "+
-		"match a recognized rule prefix; it is being treated as a helper routine. "+
+		"match a recognized rule prefix, so it is being treated as a helper routine. It was flagged because "+
+		"%s. "+
 		"Rename it to start with one of: deny, deny_<name>, violation, violation_<name>, warn, warn_<name> "+
-		"(resource-level), or stack_deny, stack_violation, stack_warn (stack-level). "+
-		"Prefixes are case-sensitive and use underscores (e.g. \"deny_public_buckets\", not \"denyPublicBuckets\").\n",
-		ruleName, module)
+		"(resource-level), or stack_deny, stack_violation, stack_warn (stack-level) — for example "+
+		"\"deny_public_buckets\", not \"denyPublicBuckets\" or \"require_versioning\". "+
+		"Prefixes are case-sensitive and use underscores. If this really is a helper routine and not a "+
+		"policy, you can ignore this warning or rename it so it no longer looks rule-like.\n",
+		ruleName, module, reason)
 }
 
 // policyPack holds the metadata for a complete Pulumi policy package.

--- a/cmd/pulumi-analyzer-policy-opa/policy.go
+++ b/cmd/pulumi-analyzer-policy-opa/policy.go
@@ -50,6 +50,17 @@ var (
 	stackWarnRulePrefix = regexp.MustCompile("^stack_warn(_[a-zA-Z0-9]+)*$")
 )
 
+// ruleLikeNamePrefix matches rule names that look like they were intended to be
+// evaluated rules but use the wrong casing, a near-miss spelling, or a malformed
+// separator (e.g. "Deny", "denies", "denyPublic", "deny-public", "stack_deniy").
+// It is deliberately anchored on the recognized intent keywords plus a few common
+// LLM/human misspellings so that legitimate helper routines (e.g. "is_public",
+// "valid_cidr", "has_encryption") never trip the warning. A match here that is NOT
+// also matched by one of the exact prefix regexes above indicates a rule that will
+// be silently skipped, which warnUnrecognizedRule reports.
+var ruleLikeNamePrefix = regexp.MustCompile(
+	`(?i)^(stack[_-]?)?(deny|denies|denied|violation|violations|violate|warn|warns|warning|warnings)`)
+
 // loadPolicyPack loads the metadata about a pack and its policies from a directory containing OPA *.rego files.
 func loadPolicyPack(dir string) (*policyPack, *evaler, error) {
 	// Read the optional PulumiPolicy.yaml manifest for pack metadata.
@@ -150,6 +161,12 @@ func loadPolicyPack(dir string) (*policyPack, *evaler, error) {
 				level = advisoryRule
 				scope = resourceScope
 			} else {
+				// This rule does not match any recognized prefix, so it will be
+				// treated as a library routine and never evaluated. If the name
+				// looks like it was *meant* to be a rule (wrong casing, a typo, or
+				// a bad separator), warn loudly so the author gets a signal instead
+				// of a rule that silently never fires.
+				warnUnrecognizedRule(ruleName, name)
 				continue // skip
 			}
 
@@ -223,6 +240,26 @@ func loadPolicyPack(dir string) (*policyPack, *evaler, error) {
 	e := &evaler{c: compiler}
 
 	return pack, e, nil
+}
+
+// warnUnrecognizedRule emits a one-time stderr warning for a rule whose name looks
+// like it was intended to be an evaluated rule but does not match a recognized
+// prefix, so it is silently treated as a helper and never runs. The message names
+// the rule, explains why it won't run, and shows how to fix it. It mirrors the
+// stderr style used by warnMissingConfig.
+//
+// Rules that don't look rule-like at all (legitimate helpers such as "is_public")
+// are not reported.
+func warnUnrecognizedRule(ruleName, module string) {
+	if !ruleLikeNamePrefix.MatchString(ruleName) {
+		return
+	}
+	fmt.Fprintf(os.Stderr, "warning: rule %q in module %q will NOT be evaluated because its name does not "+
+		"match a recognized rule prefix; it is being treated as a helper routine. "+
+		"Rename it to start with one of: deny, deny_<name>, violation, violation_<name>, warn, warn_<name> "+
+		"(resource-level), or stack_deny, stack_violation, stack_warn (stack-level). "+
+		"Prefixes are case-sensitive and use underscores (e.g. \"deny_public_buckets\", not \"denyPublicBuckets\").\n",
+		ruleName, module)
 }
 
 // policyPack holds the metadata for a complete Pulumi policy package.

--- a/cmd/pulumi-analyzer-policy-opa/policy.go
+++ b/cmd/pulumi-analyzer-policy-opa/policy.go
@@ -205,11 +205,10 @@ func loadPolicyPack(dir string) (*policyPack, *evaler, error) {
 			} else {
 				// This rule does not match any recognized prefix, so it will be
 				// treated as a library routine and never evaluated. If the rule has
-				// the shape of a policy (a partial set/object rule that builds up a
-				// collection of messages — Head.Key set, no function args) or its
-				// name looks like it was *meant* to be a rule (wrong casing, a typo,
-				// or an imperative policy verb), warn loudly so the author gets a
-				// signal instead of a rule that silently never fires.
+				// the shape of a policy (a partial set/object rule — Head.Key set, no
+				// function args) or its name looks like it was *meant* to be a rule
+				// (wrong casing, a typo, or an imperative policy verb), warn loudly so
+				// the author gets a signal instead of a rule that silently never fires.
 				policyShaped := rule.Head.Key != nil && len(rule.Head.Args) == 0
 				isFunction := len(rule.Head.Args) > 0
 				if _, warned := warnedUnrecognized[ruleName]; !warned {
@@ -335,9 +334,9 @@ func warnZeroRules(packName string, totalRules int) {
 // each name is reported at most once, even when defined across multiple bodies. There are
 // two independent triggers:
 //
-//   - policyShaped: the rule is a partial set/object rule that builds up a collection
-//     of messages (the deny/warn shape), which is the most robust signal that the
-//     author intended it as a policy regardless of what they named it; or
+//   - policyShaped: the rule is a partial set/object rule (a key, no args) — the same
+//     shape as a deny/warn rule — which is the most robust signal that the author
+//     intended it as a policy regardless of what they named it; or
 //   - its name matches ruleLikeNamePrefix — wrong casing, a near-miss spelling, or an
 //     imperative policy verb (require/must/ensure/check/...) that implies enforcement.
 //
@@ -356,9 +355,9 @@ func warnUnrecognizedRule(ruleName, module string, policyShaped, isFunction bool
 	var reason string
 	switch {
 	case policyShaped && nameLooksRuleLike:
-		reason = "it builds up a set of messages and its name implies intent to enforce a policy"
+		reason = "it has the partial set/object shape of a deny/warn rule and its name implies intent to enforce a policy"
 	case policyShaped:
-		reason = "it builds up a set of messages like a deny/warn rule"
+		reason = "it has the partial set/object shape of a deny/warn rule"
 	default:
 		reason = "its name implies intent to enforce a policy"
 	}

--- a/cmd/pulumi-analyzer-policy-opa/policy.go
+++ b/cmd/pulumi-analyzer-policy-opa/policy.go
@@ -247,11 +247,8 @@ func loadPolicyPack(dir string) (*policyPack, *evaler, error) {
 		}
 	}
 
-	// A pack that evaluates no rules at all — every rule is a helper that matches no
-	// recognized prefix, or there are no rules — silently enforces nothing, which almost
-	// always indicates an authoring bug. Warn loudly (but don't fail to load) so it can't
-	// escape notice on a published pack while staying out of the way during incremental
-	// authoring.
+	// A pack that evaluates no rules silently enforces nothing — almost always an
+	// authoring bug. Warn loudly, but don't fail to load (see warnZeroRules).
 	if len(policies) == 0 {
 		warnZeroRules(packName, totalRules)
 	}
@@ -317,7 +314,7 @@ func warnZeroRules(packName string, totalRules int) {
 
 	const bar = "========================================================================"
 	fmt.Fprintf(os.Stderr, "%s\nwarning[%s]: %s will enforce NOTHING — %s. "+
-		"Fix: name at least one rule deny_/violation_/warn_ (resource) or "+
+		"Fix: name at least one rule deny/violation/warn (resource) or "+
 		"stack_deny/stack_violation/stack_warn (stack), e.g. \"deny_public_buckets\". "+
 		"Prefixes are case-sensitive and use underscores.\n%s\n",
 		bar, diagZeroRules, name, detail, bar)

--- a/cmd/pulumi-analyzer-policy-opa/policy.go
+++ b/cmd/pulumi-analyzer-policy-opa/policy.go
@@ -165,6 +165,7 @@ func loadPolicyPack(dir string) (*policyPack, *evaler, error) {
 	var policies []*policyRule
 	totalRules := 0
 	existing := make(map[string]struct{})
+	warnedUnrecognized := make(map[string]struct{})
 	for name, module := range compiler.Modules {
 		// First determine the package name. This should match for all rules.
 		pkg := module.Package.String()
@@ -210,7 +211,12 @@ func loadPolicyPack(dir string) (*policyPack, *evaler, error) {
 				// or an imperative policy verb), warn loudly so the author gets a
 				// signal instead of a rule that silently never fires.
 				policyShaped := rule.Head.Key != nil && len(rule.Head.Args) == 0
-				warnUnrecognizedRule(ruleName, name, policyShaped)
+				isFunction := len(rule.Head.Args) > 0
+				if _, warned := warnedUnrecognized[ruleName]; !warned {
+					if warnUnrecognizedRule(ruleName, name, policyShaped, isFunction) {
+						warnedUnrecognized[ruleName] = struct{}{}
+					}
+				}
 				continue // skip
 			}
 
@@ -323,9 +329,11 @@ func warnZeroRules(packName string, totalRules int) {
 		bar, diagZeroRules, name, detail, bar)
 }
 
-// warnUnrecognizedRule emits a one-time stderr warning for a rule that does not match
-// a recognized prefix — so it is silently treated as a helper and never runs — but
-// looks like it was meant to be evaluated. There are two independent triggers:
+// warnUnrecognizedRule reports a rule that does not match a recognized prefix — so it is
+// silently treated as a helper and never runs — but looks like it was meant to be
+// evaluated. It returns true if it emitted a warning; the caller dedupes by rule name so
+// each name is reported at most once, even when defined across multiple bodies. There are
+// two independent triggers:
 //
 //   - policyShaped: the rule is a partial set/object rule that builds up a collection
 //     of messages (the deny/warn shape), which is the most robust signal that the
@@ -333,17 +341,16 @@ func warnZeroRules(packName string, totalRules int) {
 //   - its name matches ruleLikeNamePrefix — wrong casing, a near-miss spelling, or an
 //     imperative policy verb (require/must/ensure/check/...) that implies enforcement.
 //
-// The message names the rule, explains why it was flagged and why it won't run, shows
-// how to fix it, and notes that an intentional helper can be ignored or renamed so it
-// no longer looks rule-like. It mirrors the stderr style used by warnMissingConfig.
+// A function (a rule with arguments) is never reported by the name trigger, since a
+// deny/warn policy never takes arguments — so a helper like "check(x)" stays quiet.
 //
 // Rules that are neither policy-shaped nor rule-like by name (genuine boolean/value/
 // function helpers such as "is_public", "required_labels", "valid_cidr") are not
 // reported.
-func warnUnrecognizedRule(ruleName, module string, policyShaped bool) {
-	nameLooksRuleLike := ruleLikeNamePrefix.MatchString(ruleName)
+func warnUnrecognizedRule(ruleName, module string, policyShaped, isFunction bool) bool {
+	nameLooksRuleLike := !isFunction && ruleLikeNamePrefix.MatchString(ruleName)
 	if !policyShaped && !nameLooksRuleLike {
-		return
+		return false
 	}
 
 	var reason string
@@ -364,6 +371,7 @@ func warnUnrecognizedRule(ruleName, module string, policyShaped bool) {
 		"is a helper routine and not a policy, ignore this warning or rename it so it no longer looks "+
 		"rule-like.",
 		ruleName, module, reason)
+	return true
 }
 
 // policyPack holds the metadata for a complete Pulumi policy package.

--- a/cmd/pulumi-analyzer-policy-opa/policy.go
+++ b/cmd/pulumi-analyzer-policy-opa/policy.go
@@ -51,10 +51,15 @@ var (
 )
 
 // ruleLikeNamePrefix matches rule names that look like they were intended to be
-// evaluated rules but use the wrong casing, a near-miss spelling, a malformed
-// separator (e.g. "Deny", "denies", "denyPublic", "deny-public", "stack_deniy"), or
-// an imperative policy verb that implies intent to enforce something
-// (e.g. "require_versioning", "must_have_tags", "ensure_https", "check_public").
+// evaluated rules but use the wrong casing or separator or a plural/conjugated form
+// (e.g. "Deny", "denyPublic", "deny-public", "denies"), or an imperative policy verb
+// that implies intent to enforce something (e.g. "require_versioning", "must_have_tags",
+// "ensure_https", "check_public").
+//
+// This is exact-keyword matching at a word boundary, not fuzzy spelling correction: an
+// arbitrary typo like "deniy" or "violaton" is NOT matched here. Such a rule can still
+// be flagged by the other warnUnrecognizedRule trigger if it has the set-producing shape
+// of a policy.
 //
 // Each keyword must be a discrete leading token — it has to be followed by a word
 // boundary (underscore, separator, end-of-name, or a camelCase capital/digit), not
@@ -78,6 +83,22 @@ var ruleLikeNamePrefix = regexp.MustCompile(
 		`prohibit|prohibits|forbid|forbids|restrict|restricts|block|blocks|` +
 		`prevent|prevents|mandate|mandates|reject|rejects` +
 		`)(_|-|[A-Z0-9]|$)`)
+
+// Authoring-time diagnostic codes. Each warning is emitted as "warning[<code>]: ..." so
+// tooling and LLM agents can recognize and gate on a diagnostic class by its stable code
+// without depending on the exact prose, which may change between releases.
+const (
+	diagUnrecognizedRule = "opa/unrecognized-rule"
+	diagZeroRules        = "opa/zero-rules"
+	diagDuplicateRule    = "opa/duplicate-rule"
+	diagMissingConfig    = "opa/missing-config"
+)
+
+// warnf writes a single authoring-time warning to stderr, tagged with a stable diagnostic
+// code: "warning[<code>]: <message>".
+func warnf(code, format string, args ...any) {
+	fmt.Fprintf(os.Stderr, "warning[%s]: %s\n", code, fmt.Sprintf(format, args...))
+}
 
 // loadPolicyPack loads the metadata about a pack and its policies from a directory containing OPA *.rego files.
 func loadPolicyPack(dir string) (*policyPack, *evaler, error) {
@@ -142,6 +163,7 @@ func loadPolicyPack(dir string) (*policyPack, *evaler, error) {
 	// Build up a list of rules.
 	var packName string
 	var policies []*policyRule
+	totalRules := 0
 	existing := make(map[string]struct{})
 	for name, module := range compiler.Modules {
 		// First determine the package name. This should match for all rules.
@@ -158,6 +180,7 @@ func loadPolicyPack(dir string) (*policyPack, *evaler, error) {
 
 		// Next go through all rules and tease them apart, skipping duplicates.
 		for _, rule := range module.Rules {
+			totalRules++
 			ruleName := rule.Head.Name.String()
 
 			// Only process those that are legitimate errors or warnings. Other "rules" are
@@ -192,7 +215,7 @@ func loadPolicyPack(dir string) (*policyPack, *evaler, error) {
 			}
 
 			if _, has := existing[ruleName]; has {
-				fmt.Fprintf(os.Stderr, "warning: duplicate rule %q in module %q, skipping\n", ruleName, name)
+				warnf(diagDuplicateRule, "duplicate rule %q in module %q; skipping the duplicate definition", ruleName, name)
 				continue
 			}
 			existing[ruleName] = struct{}{}
@@ -222,6 +245,15 @@ func loadPolicyPack(dir string) (*policyPack, *evaler, error) {
 				Scope:       scope,
 			})
 		}
+	}
+
+	// A pack that evaluates no rules at all — every rule is a helper that matches no
+	// recognized prefix, or there are no rules — silently enforces nothing, which almost
+	// always indicates an authoring bug. Warn loudly (but don't fail to load) so it can't
+	// escape notice on a published pack while staying out of the way during incremental
+	// authoring.
+	if len(policies) == 0 {
+		warnZeroRules(packName, totalRules)
 	}
 
 	// Load optional config schemas from config-schema.json alongside the Rego files.
@@ -263,6 +295,34 @@ func loadPolicyPack(dir string) (*policyPack, *evaler, error) {
 	return pack, e, nil
 }
 
+// warnZeroRules emits a loud, stable-coded banner when a policy pack would evaluate no
+// rules at all — either because every rule is a helper that matches no recognized prefix,
+// or because the pack is empty. Such a pack silently enforces nothing, so the warning is
+// formatted to be unmissable. It is a warning rather than a hard error so incremental
+// authoring (a pack briefly with no rules) is not blocked; a CI or publish gate can key off
+// the warning[opa/zero-rules] code to fail the build if it wants stricter behavior.
+func warnZeroRules(packName string, totalRules int) {
+	name := "this policy pack"
+	if packName != "" {
+		name = fmt.Sprintf("policy pack %q", packName)
+	}
+
+	var detail string
+	if totalRules == 0 {
+		detail = "it contains no policy rules at all"
+	} else {
+		detail = fmt.Sprintf("it defines %d rule(s) but none match a recognized prefix, so every "+
+			"rule is treated as a helper and no policy will ever run", totalRules)
+	}
+
+	const bar = "========================================================================"
+	fmt.Fprintf(os.Stderr, "%s\nwarning[%s]: %s will enforce NOTHING — %s. "+
+		"Fix: name at least one rule deny_/violation_/warn_ (resource) or "+
+		"stack_deny/stack_violation/stack_warn (stack), e.g. \"deny_public_buckets\". "+
+		"Prefixes are case-sensitive and use underscores.\n%s\n",
+		bar, diagZeroRules, name, detail, bar)
+}
+
 // warnUnrecognizedRule emits a one-time stderr warning for a rule that does not match
 // a recognized prefix — so it is silently treated as a helper and never runs — but
 // looks like it was meant to be evaluated. There are two independent triggers:
@@ -296,14 +356,13 @@ func warnUnrecognizedRule(ruleName, module string, policyShaped bool) {
 		reason = "its name implies intent to enforce a policy"
 	}
 
-	fmt.Fprintf(os.Stderr, "warning: rule %q in module %q will NOT be evaluated because its name does not "+
+	warnf(diagUnrecognizedRule, "rule %q in module %q will NOT be evaluated because its name does not "+
 		"match a recognized rule prefix, so it is being treated as a helper routine. It was flagged because "+
-		"%s. "+
-		"Rename it to start with one of: deny, deny_<name>, violation, violation_<name>, warn, warn_<name> "+
-		"(resource-level), or stack_deny, stack_violation, stack_warn (stack-level) — for example "+
-		"\"deny_public_buckets\", not \"denyPublicBuckets\" or \"require_versioning\". "+
-		"Prefixes are case-sensitive and use underscores. If this really is a helper routine and not a "+
-		"policy, you can ignore this warning or rename it so it no longer looks rule-like.\n",
+		"%s. Fix: rename it to start with one of deny, violation, warn (resource-level) or stack_deny, "+
+		"stack_violation, stack_warn (stack-level) — e.g. \"deny_public_buckets\", not \"denyPublicBuckets\" "+
+		"or \"require_versioning\". Prefixes are case-sensitive and use underscores. Advisory: if this really "+
+		"is a helper routine and not a policy, ignore this warning or rename it so it no longer looks "+
+		"rule-like.",
 		ruleName, module, reason)
 }
 

--- a/cmd/pulumi-analyzer-policy-opa/policy.go
+++ b/cmd/pulumi-analyzer-policy-opa/policy.go
@@ -215,7 +215,10 @@ func loadPolicyPack(dir string) (*policyPack, *evaler, error) {
 			}
 
 			if _, has := existing[ruleName]; has {
-				warnf(diagDuplicateRule, "duplicate rule %q in module %q; skipping the duplicate definition", ruleName, name)
+				warnf(diagDuplicateRule, "rule %q in module %q has the same name as an earlier rule; OPA still "+
+					"merges and evaluates every body with this name, so no logic is dropped — only the duplicate "+
+					"policy-metadata entry is skipped. Give the rules distinct names if you meant them to be "+
+					"separate policies.", ruleName, name)
 				continue
 			}
 			existing[ruleName] = struct{}{}

--- a/cmd/pulumi-analyzer-policy-opa/policy_test.go
+++ b/cmd/pulumi-analyzer-policy-opa/policy_test.go
@@ -746,17 +746,16 @@ deny[msg] {
 	}
 
 	// Verify that a warning was emitted for the duplicate rule.
-	if !strings.Contains(stderrOutput, "warning: duplicate rule") {
+	if !strings.Contains(stderrOutput, "warning[opa/duplicate-rule]") {
 		t.Errorf("expected duplicate rule warning on stderr, got: %q", stderrOutput)
 	}
 }
 
-// loadPolicyPackCapturingStderr loads a policy pack from the given Rego source while
-// capturing everything written to os.Stderr, returning the captured output. Because it
-// swaps os.Stderr it must not run in parallel.
-func loadPolicyPackCapturingStderr(t *testing.T, rego string) (*policyPack, string) {
+// loadDirCapturingStderr loads a policy pack from dir while capturing everything written
+// to os.Stderr, returning the loaded pack, the captured output, and any load error. Because
+// it swaps os.Stderr it must not run in parallel.
+func loadDirCapturingStderr(t *testing.T, dir string) (*policyPack, string, error) {
 	t.Helper()
-	dir := writeRegoFile(t, "policy.rego", rego)
 
 	origStderr := os.Stderr
 	r, w, err := os.Pipe()
@@ -771,10 +770,19 @@ func loadPolicyPackCapturingStderr(t *testing.T, rego string) (*policyPack, stri
 	os.Stderr = origStderr
 
 	stderrBytes, _ := io.ReadAll(r)
+	return pack, string(stderrBytes), loadErr
+}
+
+// loadPolicyPackCapturingStderr loads a policy pack from the given Rego source while
+// capturing everything written to os.Stderr, returning the captured output. It fails the
+// test if loading errors. Because it swaps os.Stderr it must not run in parallel.
+func loadPolicyPackCapturingStderr(t *testing.T, rego string) (*policyPack, string) {
+	t.Helper()
+	pack, out, loadErr := loadDirCapturingStderr(t, writeRegoFile(t, "policy.rego", rego))
 	if loadErr != nil {
 		t.Fatalf("loadPolicyPack failed: %v", loadErr)
 	}
-	return pack, string(stderrBytes)
+	return pack, out
 }
 
 // TestLoadPolicies_WarnsOnUnrecognizedRule verifies that rules whose names look like
@@ -911,14 +919,18 @@ check_public[msg] {
 				t.Errorf("expected rule %q to be skipped, but it was loaded", tc.ruleName)
 			}
 
-			// A warning naming the rule and explaining the fix must be emitted.
+			// A warning naming the rule and explaining the fix must be emitted, tagged with
+			// the stable diagnostic code.
+			if !strings.Contains(stderrOutput, "warning[opa/unrecognized-rule]") {
+				t.Errorf("expected stable diagnostic code, got: %q", stderrOutput)
+			}
 			if !strings.Contains(stderrOutput, "will NOT be evaluated") {
 				t.Errorf("expected unrecognized-rule warning, got: %q", stderrOutput)
 			}
 			if !strings.Contains(stderrOutput, tc.ruleName) {
 				t.Errorf("expected warning to name the rule %q, got: %q", tc.ruleName, stderrOutput)
 			}
-			if !strings.Contains(stderrOutput, "Rename it to start with") {
+			if !strings.Contains(stderrOutput, "Fix: rename") {
 				t.Errorf("expected warning to explain the fix, got: %q", stderrOutput)
 			}
 		})
@@ -1009,4 +1021,73 @@ deny_public[msg] {
 	if strings.Contains(stderrOutput, "will NOT be evaluated") {
 		t.Errorf("did not expect unrecognized-rule warning for helpers, got: %q", stderrOutput)
 	}
+}
+
+// TestLoadPolicies_ZeroRecognizedRules verifies that a policy pack which would evaluate
+// nothing — either because every rule is a helper that matches no recognized prefix, or
+// because the pack is empty — emits a loud, stable-coded warning, but still loads without
+// error. A pack that enforces nothing is almost always an authoring bug. These tests
+// capture os.Stderr so they must not run in parallel.
+func TestLoadPolicies_ZeroRecognizedRules(t *testing.T) {
+	t.Run("OnlyHelpers", func(t *testing.T) {
+		// Genuine helpers (a boolean and a function) — neither is policy-shaped nor
+		// rule-like by name, so they produce no per-rule warning, leaving the pack-level
+		// zero-rules banner as the only signal.
+		rego := `
+package test
+
+is_public {
+    input.acl == "public-read"
+}
+
+valid_cidr(cidr) {
+    cidr != "0.0.0.0/0"
+}
+`
+		pack, stderr := loadPolicyPackCapturingStderr(t, rego)
+
+		if len(pack.Policies) != 0 {
+			t.Fatalf("expected 0 evaluable policies, got %d", len(pack.Policies))
+		}
+		if !strings.Contains(stderr, "warning[opa/zero-rules]") {
+			t.Errorf("expected zero-rules warning with stable code, got: %q", stderr)
+		}
+		if !strings.Contains(stderr, "enforce NOTHING") {
+			t.Errorf("expected the loud 'enforce NOTHING' headline, got: %q", stderr)
+		}
+	})
+
+	t.Run("EmptyPack", func(t *testing.T) {
+		pack, stderr, loadErr := loadDirCapturingStderr(t, t.TempDir())
+
+		if loadErr != nil {
+			t.Fatalf("expected no error for an empty pack, got: %v", loadErr)
+		}
+		if len(pack.Policies) != 0 {
+			t.Fatalf("expected 0 policies, got %d", len(pack.Policies))
+		}
+		if !strings.Contains(stderr, "warning[opa/zero-rules]") {
+			t.Errorf("expected zero-rules warning for empty pack, got: %q", stderr)
+		}
+	})
+
+	t.Run("NotEmittedWhenRecognizedRuleExists", func(t *testing.T) {
+		rego := `
+package test
+
+deny[msg] {
+    input.acl == "public-read"
+    msg := "public ACL not allowed"
+}
+
+is_public {
+    input.acl == "public-read"
+}
+`
+		_, stderr := loadPolicyPackCapturingStderr(t, rego)
+
+		if strings.Contains(stderr, "opa/zero-rules") {
+			t.Errorf("did not expect zero-rules warning when a recognized rule exists, got: %q", stderr)
+		}
+	})
 }

--- a/cmd/pulumi-analyzer-policy-opa/policy_test.go
+++ b/cmd/pulumi-analyzer-policy-opa/policy_test.go
@@ -928,10 +928,9 @@ check_public[msg] {
 }
 
 // TestLoadPolicies_WarnsOnPolicyShapedRule verifies the primary, name-independent
-// trigger: a partial set rule that builds up a collection of messages (the deny/warn
-// shape) is flagged even when its name matches no keyword heuristic, because its shape
-// is the strongest signal the author meant it to be a policy. This test captures
-// os.Stderr so it must not run in parallel.
+// trigger: a partial set/object rule (the deny/warn shape) is flagged even when its name
+// matches no keyword heuristic, because its shape is the strongest signal the author meant
+// it to be a policy. This test captures os.Stderr so it must not run in parallel.
 func TestLoadPolicies_WarnsOnPolicyShapedRule(t *testing.T) {
 	rego := `
 package test
@@ -952,8 +951,8 @@ s3_bucket_policy[msg] {
 	if !strings.Contains(stderrOutput, "s3_bucket_policy") {
 		t.Errorf("expected warning to name the rule, got: %q", stderrOutput)
 	}
-	if !strings.Contains(stderrOutput, "set of messages") {
-		t.Errorf("expected warning to cite the set-producing shape, got: %q", stderrOutput)
+	if !strings.Contains(stderrOutput, "shape of a deny/warn rule") {
+		t.Errorf("expected warning to cite the deny/warn shape, got: %q", stderrOutput)
 	}
 }
 

--- a/cmd/pulumi-analyzer-policy-opa/policy_test.go
+++ b/cmd/pulumi-analyzer-policy-opa/policy_test.go
@@ -848,6 +848,58 @@ warning_no_tags[msg] {
 }
 `,
 		},
+		{
+			// The owner's explicit example: an imperative policy verb with no
+			// recognized prefix. Caught by both the broadened name heuristic and the
+			// set-producing shape.
+			name:     "ImperativeRequire",
+			ruleName: "require_versioning",
+			rego: `
+package test
+
+require_versioning[msg] {
+    input.type == "aws:s3/bucket:Bucket"
+    not input.versioning.enabled
+    msg := "versioning must be enabled"
+}
+`,
+		},
+		{
+			name:     "ImperativeMust",
+			ruleName: "must_have_tags",
+			rego: `
+package test
+
+must_have_tags[msg] {
+    not input.tags
+    msg := "resources must have tags"
+}
+`,
+		},
+		{
+			name:     "ImperativeEnsure",
+			ruleName: "ensure_https",
+			rego: `
+package test
+
+ensure_https[msg] {
+    input.protocol != "https"
+    msg := "https must be used"
+}
+`,
+		},
+		{
+			name:     "ImperativeCheck",
+			ruleName: "check_public",
+			rego: `
+package test
+
+check_public[msg] {
+    input.acl == "public-read"
+    msg := "public ACL not allowed"
+}
+`,
+		},
 	}
 
 	for _, tc := range cases {
@@ -873,10 +925,43 @@ warning_no_tags[msg] {
 	}
 }
 
+// TestLoadPolicies_WarnsOnPolicyShapedRule verifies the primary, name-independent
+// trigger: a partial set rule that builds up a collection of messages (the deny/warn
+// shape) is flagged even when its name matches no keyword heuristic, because its shape
+// is the strongest signal the author meant it to be a policy. This test captures
+// os.Stderr so it must not run in parallel.
+func TestLoadPolicies_WarnsOnPolicyShapedRule(t *testing.T) {
+	rego := `
+package test
+
+s3_bucket_policy[msg] {
+    input.acl == "public-read"
+    msg := "public ACL not allowed"
+}
+`
+	pack, stderrOutput := loadPolicyPackCapturingStderr(t, rego)
+
+	if findRule(pack, "s3_bucket_policy") != nil {
+		t.Error("expected policy-shaped but unprefixed rule to be skipped, but it was loaded")
+	}
+	if !strings.Contains(stderrOutput, "will NOT be evaluated") {
+		t.Errorf("expected warning for policy-shaped rule, got: %q", stderrOutput)
+	}
+	if !strings.Contains(stderrOutput, "s3_bucket_policy") {
+		t.Errorf("expected warning to name the rule, got: %q", stderrOutput)
+	}
+	if !strings.Contains(stderrOutput, "set of messages") {
+		t.Errorf("expected warning to cite the set-producing shape, got: %q", stderrOutput)
+	}
+}
+
 // TestLoadPolicies_NoWarnOnLegitimateHelpers verifies that genuine helper routines —
-// names that do not look like a mistyped rule — are silently treated as library
-// routines without triggering the unrecognized-rule warning.
-// This test captures os.Stderr so it must not run in parallel.
+// boolean rules, value rules, and functions whose names do not look like a mistyped
+// rule — are silently treated as library routines without triggering the
+// unrecognized-rule warning. These are distinguished from policies by shape: a real
+// policy is a partial set/object rule (Head.Key set, no args), whereas helpers are
+// booleans, values, or functions. This test captures os.Stderr so it must not run in
+// parallel.
 func TestLoadPolicies_NoWarnOnLegitimateHelpers(t *testing.T) {
 	rego := `
 package test
@@ -885,34 +970,42 @@ is_public {
     input.acl == "public-read"
 }
 
-valid_cidr(cidr) {
-    cidr != "0.0.0.0/0"
+is_exempt {
+    input.tags.exempt == "true"
 }
 
 has_encryption {
     input.serverSideEncryptionConfiguration
 }
 
-deny[msg] {
+required_labels = ["env", "owner"]
+
+valid_cidr(cidr) {
+    cidr != "0.0.0.0/0"
+}
+
+deny_public[msg] {
     is_public
+    not is_exempt
     msg := "public ACL not allowed"
 }
 `
 	pack, stderrOutput := loadPolicyPackCapturingStderr(t, rego)
 
-	// The real rule should still load.
-	if findRule(pack, "deny") == nil {
-		t.Error("expected deny rule to be loaded")
+	// The real rule should still load with no warning.
+	if findRule(pack, "deny_public") == nil {
+		t.Error("expected deny_public rule to be loaded")
 	}
 
-	// None of the helpers should be loaded as evaluated rules.
-	for _, helper := range []string{"is_public", "valid_cidr", "has_encryption"} {
+	// None of the helpers should be loaded as evaluated rules; they remain usable as
+	// library routines (deny_public above references is_public/is_exempt and compiles).
+	for _, helper := range []string{"is_public", "is_exempt", "has_encryption", "required_labels", "valid_cidr"} {
 		if findRule(pack, helper) != nil {
 			t.Errorf("helper %q should not be loaded as a policy", helper)
 		}
 	}
 
-	// No unrecognized-rule warning should have been emitted.
+	// No unrecognized-rule warning should have been emitted for any helper.
 	if strings.Contains(stderrOutput, "will NOT be evaluated") {
 		t.Errorf("did not expect unrecognized-rule warning for helpers, got: %q", stderrOutput)
 	}

--- a/cmd/pulumi-analyzer-policy-opa/policy_test.go
+++ b/cmd/pulumi-analyzer-policy-opa/policy_test.go
@@ -715,21 +715,7 @@ deny[msg] {
 	}
 
 	// Capture stderr to verify the duplicate warning is emitted.
-	origStderr := os.Stderr
-	r, w, err := os.Pipe()
-	if err != nil {
-		t.Fatalf("failed to create pipe: %v", err)
-	}
-	os.Stderr = w
-
-	pack, _, loadErr := loadPolicyPack(dir)
-
-	_ = w.Close()
-	os.Stderr = origStderr
-
-	stderrBytes, _ := io.ReadAll(r)
-	stderrOutput := string(stderrBytes)
-
+	pack, stderrOutput, loadErr := loadDirCapturingStderr(t, dir)
 	if loadErr != nil {
 		t.Fatalf("loadPolicyPack failed: %v", loadErr)
 	}
@@ -769,7 +755,11 @@ func loadDirCapturingStderr(t *testing.T, dir string) (*policyPack, string, erro
 	_ = w.Close()
 	os.Stderr = origStderr
 
-	stderrBytes, _ := io.ReadAll(r)
+	stderrBytes, readErr := io.ReadAll(r)
+	if readErr != nil {
+		t.Fatalf("failed to read captured stderr: %v", readErr)
+	}
+	_ = r.Close()
 	return pack, string(stderrBytes), loadErr
 }
 

--- a/cmd/pulumi-analyzer-policy-opa/policy_test.go
+++ b/cmd/pulumi-analyzer-policy-opa/policy_test.go
@@ -750,3 +750,170 @@ deny[msg] {
 		t.Errorf("expected duplicate rule warning on stderr, got: %q", stderrOutput)
 	}
 }
+
+// loadPolicyPackCapturingStderr loads a policy pack from the given Rego source while
+// capturing everything written to os.Stderr, returning the captured output. Because it
+// swaps os.Stderr it must not run in parallel.
+func loadPolicyPackCapturingStderr(t *testing.T, rego string) (*policyPack, string) {
+	t.Helper()
+	dir := writeRegoFile(t, "policy.rego", rego)
+
+	origStderr := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed to create pipe: %v", err)
+	}
+	os.Stderr = w
+
+	pack, _, loadErr := loadPolicyPack(dir)
+
+	_ = w.Close()
+	os.Stderr = origStderr
+
+	stderrBytes, _ := io.ReadAll(r)
+	if loadErr != nil {
+		t.Fatalf("loadPolicyPack failed: %v", loadErr)
+	}
+	return pack, string(stderrBytes)
+}
+
+// TestLoadPolicies_WarnsOnUnrecognizedRule verifies that rules whose names look like
+// they were intended to be evaluated rules — but use the wrong casing, a near-miss
+// spelling, or a bad separator — produce a loud stderr warning and are not evaluated.
+// These tests capture os.Stderr so they must not run in parallel.
+func TestLoadPolicies_WarnsOnUnrecognizedRule(t *testing.T) {
+	cases := []struct {
+		name     string
+		ruleName string
+		rego     string
+	}{
+		{
+			name:     "WrongCase",
+			ruleName: "denyPublicBuckets",
+			rego: `
+package test
+
+denyPublicBuckets[msg] {
+    input.acl == "public-read"
+    msg := "public ACL not allowed"
+}
+`,
+		},
+		{
+			name:     "Misspelling",
+			ruleName: "denies_public",
+			rego: `
+package test
+
+denies_public[msg] {
+    input.acl == "public-read"
+    msg := "public ACL not allowed"
+}
+`,
+		},
+		{
+			name:     "StackMisspelling",
+			ruleName: "stack_denies_public",
+			rego: `
+package test
+
+stack_denies_public[msg] {
+    r := input.resources[_]
+    r.acl == "public-read"
+    msg := "public ACL not allowed"
+}
+`,
+		},
+		{
+			name:     "StackWrongCase",
+			ruleName: "stackDeny",
+			rego: `
+package test
+
+stackDeny[msg] {
+    count(input.resources) > 10
+    msg := "too many resources"
+}
+`,
+		},
+		{
+			name:     "WarningTypo",
+			ruleName: "warning_no_tags",
+			rego: `
+package test
+
+warning_no_tags[msg] {
+    not input.tags
+    msg := "missing tags"
+}
+`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			pack, stderrOutput := loadPolicyPackCapturingStderr(t, tc.rego)
+
+			// The rule must not have been loaded as an evaluated policy.
+			if r := findRule(pack, tc.ruleName); r != nil {
+				t.Errorf("expected rule %q to be skipped, but it was loaded", tc.ruleName)
+			}
+
+			// A warning naming the rule and explaining the fix must be emitted.
+			if !strings.Contains(stderrOutput, "will NOT be evaluated") {
+				t.Errorf("expected unrecognized-rule warning, got: %q", stderrOutput)
+			}
+			if !strings.Contains(stderrOutput, tc.ruleName) {
+				t.Errorf("expected warning to name the rule %q, got: %q", tc.ruleName, stderrOutput)
+			}
+			if !strings.Contains(stderrOutput, "Rename it to start with") {
+				t.Errorf("expected warning to explain the fix, got: %q", stderrOutput)
+			}
+		})
+	}
+}
+
+// TestLoadPolicies_NoWarnOnLegitimateHelpers verifies that genuine helper routines —
+// names that do not look like a mistyped rule — are silently treated as library
+// routines without triggering the unrecognized-rule warning.
+// This test captures os.Stderr so it must not run in parallel.
+func TestLoadPolicies_NoWarnOnLegitimateHelpers(t *testing.T) {
+	rego := `
+package test
+
+is_public {
+    input.acl == "public-read"
+}
+
+valid_cidr(cidr) {
+    cidr != "0.0.0.0/0"
+}
+
+has_encryption {
+    input.serverSideEncryptionConfiguration
+}
+
+deny[msg] {
+    is_public
+    msg := "public ACL not allowed"
+}
+`
+	pack, stderrOutput := loadPolicyPackCapturingStderr(t, rego)
+
+	// The real rule should still load.
+	if findRule(pack, "deny") == nil {
+		t.Error("expected deny rule to be loaded")
+	}
+
+	// None of the helpers should be loaded as evaluated rules.
+	for _, helper := range []string{"is_public", "valid_cidr", "has_encryption"} {
+		if findRule(pack, helper) != nil {
+			t.Errorf("helper %q should not be loaded as a policy", helper)
+		}
+	}
+
+	// No unrecognized-rule warning should have been emitted.
+	if strings.Contains(stderrOutput, "will NOT be evaluated") {
+		t.Errorf("did not expect unrecognized-rule warning for helpers, got: %q", stderrOutput)
+	}
+}

--- a/cmd/pulumi-analyzer-policy-opa/policy_test.go
+++ b/cmd/pulumi-analyzer-policy-opa/policy_test.go
@@ -1013,6 +1013,33 @@ deny_public[msg] {
 	}
 }
 
+// TestLoadPolicies_NoWarnOnFunctionHelper verifies that a function (a rule with arguments)
+// is never flagged by the name heuristic, even when its name matches a rule-like keyword
+// like "check" — a deny/warn policy never takes arguments, so a function is unambiguously a
+// helper. This test captures os.Stderr so it must not run in parallel.
+func TestLoadPolicies_NoWarnOnFunctionHelper(t *testing.T) {
+	rego := `
+package test
+
+check(resource) {
+    resource.acl == "public-read"
+}
+
+deny_public[msg] {
+    check(input)
+    msg := "public ACL not allowed"
+}
+`
+	pack, stderrOutput := loadPolicyPackCapturingStderr(t, rego)
+
+	if findRule(pack, "deny_public") == nil {
+		t.Error("expected deny_public rule to be loaded")
+	}
+	if strings.Contains(stderrOutput, "will NOT be evaluated") {
+		t.Errorf("did not expect a warning for the function helper check(), got: %q", stderrOutput)
+	}
+}
+
 // TestLoadPolicies_ZeroRecognizedRules verifies that a policy pack which would evaluate
 // nothing — either because every rule is a helper that matches no recognized prefix, or
 // because the pack is empty — emits a loud, stable-coded warning, but still loads without


### PR DESCRIPTION
## Why

Authoring a Rego policy pack against real cloud state and getting the idiom slightly wrong fails **silently** today. A misnamed rule is treated as a helper and never runs; reaching for the Node Policy SDK's `args.props` (or any unrecognized property path) just evaluates to `undefined`. The rule then fires on 0% or 100% of resources with no error and no signal — the exact failure mode an LLM (or human) hits when it doesn't write perfect Rego on the first try.

This makes those failures actionable.

## What

- **Warn on rules that won't be evaluated** (Fixes #38) — when a rule lacks a recognized prefix (`deny`/`violation`/`warn`/`stack_*`) but is *policy-shaped* (a set-of-messages rule like `require_versioning[msg]`) or its name implies intent (`must_*`, `ensure_*`, `check_*`, wrong case, near-miss spelling), emit a one-time stderr warning that names the rule, says it will not run, and shows how to rename it. Detection is primarily by **rule shape** (`Head.Key != nil`, no args), so genuine helpers (`is_exempt`, `required_labels`, `valid_cidr`) stay quiet.
- **Warn when the whole pack evaluates nothing** — a pack where no rule matches a recognized prefix (or that has no rules at all) would silently enforce nothing, so it now emits a prominent `warning[opa/zero-rules]` banner. Non-blocking, so incremental authoring isn't gated; the stable code lets CI/publish gate on it.
- **Stable, machine-readable diagnostic codes** — every authoring-time warning is tagged with a stable `warning[opa/<code>]` identifier (`opa/unrecognized-rule`, `opa/zero-rules`, `opa/duplicate-rule`, `opa/missing-config`) plus an explicit `Fix:` clause, so CI and LLM agents can recognize and act on a diagnostic class without parsing prose.
- **`input.props` / `input.__props` alias** (Fixes #40) — project resource properties under `props`/`__props` as a backward-compatible alias of the existing `properties` bag, so authors porting from the Node SDK's `args.props` land on real data instead of `undefined`.
- **README idioms** (Addresses #39) — lead the rules section with "the name prefix is the API"; add a ✅/❌ naming table (covering the correctly-spelled-but-wrong-API case like `require_https`); add an idiom table for the traps that silently fire on 0%/100% of resources. The "collection is empty or missing" idiom is `count(object.get(input, "tags", [])) == 0` — bare `count(input.tags) == 0` is `undefined` (so never matches) when the key is absent, and `not input.tags` only catches a missing key. An undefined property reference matches nothing — or *everything* under `not`. These are core OPA semantics, documented here, not changed; the detecting runtime warning is tracked in #41.

## Left as issue-only

The 0%/100% **vacuous/dead-rule** runtime warning (#41) is intentionally not implemented here: it needs per-evaluation outcome tracking with an end-of-stack hook the analyzer interface doesn't expose at this layer, and a 100%-firing rule can be legitimate, so it isn't cleanly bounded.

## Tests

`go build ./... && go test ./...` passes. New tests assert: the unrecognized-rule warning fires for misnamed/policy-shaped rules (including `require_versioning`, `must_have_tags`, `ensure_https`, `check_public`) and stays quiet for legitimate helpers; the `warning[opa/zero-rules]` banner fires for an all-helper pack and an empty pack but not when a recognized rule exists; and `props`/`__props` mirror `properties` (including the top-level collision case). The corrected Rego idiom guidance was verified empirically against the OPA evaluator. CHANGELOG updated.

Fixes #38, #40. Addresses #39. #41 tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
